### PR TITLE
impl valuable traits for more types, fix build error on no_std + alloc

### DIFF
--- a/valuable/Cargo.toml
+++ b/valuable/Cargo.toml
@@ -13,7 +13,7 @@ default = ["std"]
 derive = ["valuable-derive"]
 
 # Provide impls for common standard library types like Vec<T> and HashMap<K, V>.
-std = []
+std = ["alloc"]
 
 # Provide imps for types in Rust's `alloc` library.
 alloc = []

--- a/valuable/src/enumerable.rs
+++ b/valuable/src/enumerable.rs
@@ -1,6 +1,8 @@
 use crate::field::*;
 use crate::*;
 
+#[cfg(feature = "alloc")]
+use alloc::format;
 use core::fmt;
 
 pub trait Enumerable: Valuable {
@@ -139,5 +141,32 @@ impl fmt::Debug for dyn Enumerable + '_ {
 
         self.visit(&mut visit);
         visit.res
+    }
+}
+
+impl<E: ?Sized + Enumerable> Enumerable for &E {
+    fn definition(&self) -> EnumDef<'_> {
+        E::definition(*self)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<E: ?Sized + Enumerable> Enumerable for alloc::boxed::Box<E> {
+    fn definition(&self) -> EnumDef<'_> {
+        E::definition(&**self)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<E: ?Sized + Enumerable> Enumerable for alloc::rc::Rc<E> {
+    fn definition(&self) -> EnumDef<'_> {
+        E::definition(&**self)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<E: ?Sized + Enumerable> Enumerable for alloc::sync::Arc<E> {
+    fn definition(&self) -> EnumDef<'_> {
+        E::definition(&**self)
     }
 }

--- a/valuable/src/listable.rs
+++ b/valuable/src/listable.rs
@@ -12,7 +12,22 @@ impl<L: ?Sized + Listable> Listable for &L {
     }
 }
 
-impl<L: ?Sized + Listable> Listable for Box<L> {
+#[cfg(feature = "alloc")]
+impl<L: ?Sized + Listable> Listable for alloc::boxed::Box<L> {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        L::size_hint(&**self)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<L: ?Sized + Listable> Listable for alloc::rc::Rc<L> {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        L::size_hint(&**self)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<L: ?Sized + Listable> Listable for alloc::sync::Arc<L> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         L::size_hint(&**self)
     }
@@ -24,7 +39,21 @@ impl<T: Valuable> Listable for &'_ [T] {
     }
 }
 
-impl<T: Valuable> Listable for Vec<T> {
+#[cfg(feature = "alloc")]
+impl<T: Valuable> Listable for alloc::boxed::Box<[T]> {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+impl<T: Valuable, const N: usize> Listable for [T; N] {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Valuable> Listable for alloc::vec::Vec<T> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len(), Some(self.len()))
     }

--- a/valuable/src/slice.rs
+++ b/valuable/src/slice.rs
@@ -115,7 +115,7 @@ slice! {
     I128(i128),
     Isize(isize),
     Str(&'a str),
-    String(String),
+    String(alloc::string::String),
     U8(u8),
     U16(u16),
     U32(u32),

--- a/valuable/src/structable.rs
+++ b/valuable/src/structable.rs
@@ -6,6 +6,7 @@ use core::fmt;
 pub trait Structable: Valuable {
     fn definition(&self) -> StructDef<'_>;
 }
+
 pub struct StructDef<'a> {
     /// Type name
     name: &'a str,
@@ -78,5 +79,32 @@ impl<'a> StructDef<'a> {
 
     pub fn is_dynamic(&self) -> bool {
         self.is_dynamic
+    }
+}
+
+impl<S: ?Sized + Structable> Structable for &S {
+    fn definition(&self) -> StructDef<'_> {
+        S::definition(*self)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<S: ?Sized + Structable> Structable for alloc::boxed::Box<S> {
+    fn definition(&self) -> StructDef<'_> {
+        S::definition(&**self)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<S: ?Sized + Structable> Structable for alloc::rc::Rc<S> {
+    fn definition(&self) -> StructDef<'_> {
+        S::definition(&**self)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<S: ?Sized + Structable> Structable for alloc::sync::Arc<S> {
+    fn definition(&self) -> StructDef<'_> {
+        S::definition(&**self)
     }
 }

--- a/valuable/src/value.rs
+++ b/valuable/src/value.rs
@@ -5,6 +5,7 @@ use core::fmt;
 macro_rules! value {
     (
         $(
+            $(#[$attrs:meta])*
             $variant:ident($ty:ty),
         )*
     ) => {
@@ -12,12 +13,14 @@ macro_rules! value {
         #[derive(Clone, Copy)]
         pub enum Value<'a> {
             $(
+                $(#[$attrs])*
                 $variant($ty),
             )*
             Unit, // TODO: None?
         }
 
         $(
+            $(#[$attrs])*
             impl<'a> From<$ty> for Value<'a> {
                 fn from(src: $ty) -> Value<'a> {
                     Value::$variant(src)
@@ -37,6 +40,7 @@ macro_rules! value {
 
                 match self {
                     $(
+                        $(#[$attrs])*
                         $variant(v) => fmt::Debug::fmt(v, fmt),
                     )*
                     Unit => ().fmt(fmt),
@@ -64,6 +68,7 @@ value! {
     U64(u64),
     U128(u128),
     Usize(usize),
+    #[cfg(feature = "std")]
     Error(&'a dyn std::error::Error),
     Listable(&'a dyn Listable),
     Mappable(&'a dyn Mappable),
@@ -159,6 +164,7 @@ macro_rules! convert {
                 }
             }
 
+            #[cfg(feature = "std")]
             pub fn as_error(&self) -> Option<&dyn std::error::Error> {
                 match *self {
                     Value::Error(v) => Some(v),


### PR DESCRIPTION
- impl valuable traits (Valuable, Mappable, Listable, etc.) for Box, Rc, Arc, reference
- impl Valuable/Mappable for BTreeMap
- impl Valuable/Listable for array ([T; N])
- fix build error on no_std + alloc
  The current master fails to build on no_std + alloc (I noticed this problem when I was implementing valuable traits for Box). This patch fixes it.
  ```console
  cargo build --target thumbv7m-none-eabi --no-default-features --features alloc,derive -p valuable
  ```