### PR TITLE
expose enum current variant from Enumerable trait

### DIFF
--- a/tests/src/visit_count.rs
+++ b/tests/src/visit_count.rs
@@ -5,8 +5,6 @@ pub struct VisitCount {
     pub visit_value: u32,
     pub visit_named_fields: u32,
     pub visit_unnamed_fields: u32,
-    pub visit_variant_named_fields: u32,
-    pub visit_variant_unnamed_fields: u32,
     pub visit_slice: u32,
     pub visit_entry: u32,
 }
@@ -28,14 +26,6 @@ impl Visit for VisitCount {
 
     fn visit_unnamed_fields(&mut self, _: &[Value<'_>]) {
         self.visit_unnamed_fields += 1;
-    }
-
-    fn visit_variant_named_fields(&mut self, _: &Variant<'_>, _: &NamedValues<'_>) {
-        self.visit_variant_named_fields += 1;
-    }
-
-    fn visit_variant_unnamed_fields(&mut self, _: &Variant<'_>, _: &[Value<'_>]) {
-        self.visit_variant_unnamed_fields += 1;
     }
 
     fn visit_slice(&mut self, _: Slice<'_>) {

--- a/tests/tests/enumerable.rs
+++ b/tests/tests/enumerable.rs
@@ -20,6 +20,14 @@ fn test_manual_static_impl() {
         fn definition(&self) -> EnumDef<'_> {
             EnumDef::new("Enum", ENUM_VARIANTS, false)
         }
+
+        fn variant(&self) -> Variant<'_> {
+            match *self {
+                Enum::Struct { .. } => Variant::Static(&ENUM_VARIANTS[0]),
+                Enum::Tuple(..) => Variant::Static(&ENUM_VARIANTS[1]),
+                Enum::Unit => Variant::Static(&ENUM_VARIANTS[2]),
+            }
+        }
     }
 
     impl Valuable for Enum {
@@ -30,16 +38,16 @@ fn test_manual_static_impl() {
         fn visit(&self, visitor: &mut dyn Visit) {
             match self {
                 Enum::Struct { x } => {
-                    visitor.visit_variant_named_fields(
-                        &Variant::new("Struct"),
-                        &NamedValues::new(ENUM_STRUCT_FIELDS, &[Value::String(x)]),
-                    );
+                    visitor.visit_named_fields(&NamedValues::new(
+                        ENUM_STRUCT_FIELDS,
+                        &[Value::String(x)],
+                    ));
                 }
                 Enum::Tuple(y) => {
-                    visitor.visit_variant_unnamed_fields(&Variant::new("Tuple"), &[Value::U8(*y)]);
+                    visitor.visit_unnamed_fields(&[Value::U8(*y)]);
                 }
                 Enum::Unit => {
-                    visitor.visit_variant_unnamed_fields(&Variant::new("Unit"), &[]);
+                    visitor.visit_unnamed_fields(&[]);
                 }
             }
         }

--- a/valuable/src/visit.rs
+++ b/valuable/src/visit.rs
@@ -16,18 +16,6 @@ pub trait Visit {
         drop(values);
     }
 
-    fn visit_variant_named_fields(
-        &mut self,
-        variant: &Variant<'_>,
-        named_values: &NamedValues<'_>,
-    ) {
-        drop((variant, named_values));
-    }
-
-    fn visit_variant_unnamed_fields(&mut self, variant: &Variant<'_>, values: &[Value<'_>]) {
-        drop((variant, values));
-    }
-
     /// Visit a slice
     fn visit_slice(&mut self, slice: Slice<'_>) {
         drop(slice);


### PR DESCRIPTION
This simplifies the API a bit. I exposed some friction when trying to properly implement fmt for Enumerable. This means we don't need to pass the variant to the visitor and can reuse the `visit_named_fields` and `visit_unnamed_fields` visitor fns.