### PR TITLE
Fix build error when alloc feature is disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: rustup update stable
       - name: Install cargo-hack
         run: cargo install cargo-hack
-      - run: cargo hack build --workspace --feature-powerset --no-dev-deps
+      - run: cargo hack build --workspace --feature-powerset
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,28 +36,24 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - run: rustup target add ${{ matrix.target }}
-      # TODO: Currently, valuable cannot build without `alloc` feature
-      #       because `Debug` impl of `dyn Enumerable` uses `format!` macro.
-      # - run: cargo build --target ${{ matrix.target }} --no-default-features
-      #   working-directory: valuable
-      # - run: cargo build --target ${{ matrix.target }} --no-default-features --features derive
-      #   working-directory: valuable
+      - run: cargo build --target ${{ matrix.target }} --no-default-features
+        working-directory: valuable
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --features derive
+        working-directory: valuable
       - run: cargo build --target ${{ matrix.target }} --no-default-features --features alloc
         working-directory: valuable
       - run: cargo build --target ${{ matrix.target }} --no-default-features --features alloc,derive
         working-directory: valuable
 
-  # TODO: Currently, valuable cannot build without `alloc` feature
-  #       because `Debug` impl of `dyn Enumerable` uses `format!` macro.
-  # features:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install Rust
-  #       run: rustup update stable
-  #     - name: Install cargo-hack
-  #       run: cargo install cargo-hack
-  #     - run: cargo hack build --workspace --feature-powerset --no-dev-deps
+  features:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
+      - run: cargo hack build --workspace --feature-powerset --no-dev-deps
 
   fmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
     "valuable",
     "valuable-derive",

--- a/valuable/src/enumerable.rs
+++ b/valuable/src/enumerable.rs
@@ -133,9 +133,11 @@ impl<'a> DynamicVariant<'a> {
 
 impl fmt::Debug for dyn Enumerable + '_ {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let def = self.definition();
         let variant = self.variant();
-        let name = format!("{}::{}", def.name(), variant.name());
+        #[cfg(feature = "alloc")]
+        let name = format!("{}::{}", self.definition().name(), variant.name());
+        #[cfg(not(feature = "alloc"))]
+        let name = variant.name();
 
         if variant.is_named_fields() {
             struct DebugEnum<'a, 'b> {

--- a/valuable/src/slice.rs
+++ b/valuable/src/slice.rs
@@ -5,12 +5,14 @@ use core::fmt;
 macro_rules! slice {
     (
         $(
+            $(#[$attrs:meta])*
             $variant:ident($ty:ty),
         )*
     ) => {
         #[non_exhaustive]
         pub enum Slice<'a> {
             $(
+                $(#[$attrs])*
                 $variant(&'a [$ty]),
             )*
         }
@@ -19,6 +21,7 @@ macro_rules! slice {
 
         enum IterKind<'a> {
             $(
+                $(#[$attrs])*
                 $variant(core::slice::Iter<'a, $ty>),
             )*
         }
@@ -27,6 +30,7 @@ macro_rules! slice {
             pub fn len(&self) -> usize {
                 match self {
                     $(
+                        $(#[$attrs])*
                         Slice::$variant(s) => s.len(),
                     )*
                 }
@@ -53,6 +57,7 @@ macro_rules! slice {
             fn into_iter(self) -> Self::IntoIter {
                 Iter(match self {
                     $(
+                        $(#[$attrs])*
                         Slice::$variant(s) => IterKind::$variant(s.iter()),
                     )*
                 })
@@ -67,6 +72,7 @@ macro_rules! slice {
 
                 match *self {
                     $(
+                        $(#[$attrs])*
                         $variant(v) => d.entries(v),
                     )*
                 };
@@ -83,6 +89,7 @@ macro_rules! slice {
 
                 match &self.0 {
                     $(
+                        $(#[$attrs])*
                         $variant(v) => v.size_hint(),
                     )*
                 }
@@ -93,6 +100,7 @@ macro_rules! slice {
 
                 match &mut self.0 {
                     $(
+                        $(#[$attrs])*
                         $variant(v) => v.next().map(|v| {
                             Valuable::as_value(v)
                         }),
@@ -115,6 +123,7 @@ slice! {
     I128(i128),
     Isize(isize),
     Str(&'a str),
+    #[cfg(feature = "alloc")]
     String(alloc::string::String),
     U8(u8),
     U16(u16),


### PR DESCRIPTION
Fixes build error by the way mentioned in https://github.com/tokio-rs/valuable/pull/10#discussion_r630179884.

> print only variant name when alloc feature is disabled? (like the following)
> 
> ```rust
> #[cfg(feature = "alloc")]
> let name = format!("{}::{}", self.name, variant.name());
> #[cfg(not(feature = "alloc"))]
> let name = variant.name();
> ```

