### PR TITLE
impl Listable for std collections

### DIFF
--- a/valuable/src/listable.rs
+++ b/valuable/src/listable.rs
@@ -33,174 +33,90 @@ impl<L: ?Sized + Listable> Listable for alloc::sync::Arc<L> {
     }
 }
 
-impl<T: Valuable> Listable for &'_ [T] {
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
-    }
+macro_rules! slice {
+    (
+        $(
+            $(#[$attrs:meta])*
+            ($($generics:tt)*) $ty:ty,
+        )*
+    ) => {
+        $(
+            $(#[$attrs])*
+            impl<$($generics)*> Valuable for $ty {
+                fn as_value(&self) -> Value<'_> {
+                    Value::Listable(self as &dyn Listable)
+                }
+
+                fn visit(&self, visit: &mut dyn Visit) {
+                    T::visit_slice(self, visit);
+                }
+            }
+
+            $(#[$attrs])*
+            impl<$($generics)*> Listable for $ty {
+                fn size_hint(&self) -> (usize, Option<usize>) {
+                    (self.len(), Some(self.len()))
+                }
+            }
+        )*
+    };
 }
 
-#[cfg(feature = "alloc")]
-impl<T: Valuable> Listable for alloc::boxed::Box<[T]> {
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
-    }
+slice! {
+    (T: Valuable) &'_ [T],
+    #[cfg(feature = "alloc")]
+    (T: Valuable) alloc::boxed::Box<[T]>,
+    #[cfg(feature = "alloc")]
+    (T: Valuable) alloc::rc::Rc<[T]>,
+    #[cfg(feature = "alloc")]
+    (T: Valuable) alloc::sync::Arc<[T]>,
+    (T: Valuable, const N: usize) [T; N],
+    #[cfg(feature = "alloc")]
+    (T: Valuable) alloc::vec::Vec<T>,
 }
 
-#[cfg(feature = "alloc")]
-impl<T: Valuable> Valuable for alloc::rc::Rc<[T]> {
-    fn as_value(&self) -> Value<'_> {
-        Value::Listable(self)
-    }
+macro_rules! collection {
+    (
+        $(
+            $(#[$attrs:meta])*
+            ($($generics:tt)*) $ty:ty,
+        )*
+    ) => {
+        $(
+            $(#[$attrs])*
+            impl<$($generics)*> Valuable for $ty {
+                fn as_value(&self) -> Value<'_> {
+                    Value::Listable(self as &dyn Listable)
+                }
 
-    fn visit(&self, visit: &mut dyn Visit) {
-        T::visit_slice(self, visit);
-    }
+                fn visit(&self, visit: &mut dyn Visit) {
+                    for value in self.iter() {
+                        visit.visit_value(value.as_value());
+                    }
+                }
+            }
+
+            $(#[$attrs])*
+            impl<$($generics)*> Listable for $ty {
+                fn size_hint(&self) -> (usize, Option<usize>) {
+                    (self.len(), Some(self.len()))
+                }
+            }
+        )*
+    };
 }
 
-#[cfg(feature = "alloc")]
-impl<T: Valuable> Listable for alloc::rc::Rc<[T]> {
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable> Valuable for alloc::sync::Arc<[T]> {
-    fn as_value(&self) -> Value<'_> {
-        Value::Listable(self)
-    }
-
-    fn visit(&self, visit: &mut dyn Visit) {
-        T::visit_slice(self, visit);
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable> Listable for alloc::sync::Arc<[T]> {
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
-    }
-}
-
-impl<T: Valuable, const N: usize> Listable for [T; N] {
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable> Listable for alloc::vec::Vec<T> {
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable> Valuable for alloc::collections::VecDeque<T> {
-    fn as_value(&self) -> Value<'_> {
-        Value::Listable(self)
-    }
-
-    fn visit(&self, visit: &mut dyn Visit) {
-        for value in self.iter() {
-            visit.visit_value(value.as_value());
-        }
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable> Listable for alloc::collections::VecDeque<T> {
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable> Valuable for alloc::collections::LinkedList<T> {
-    fn as_value(&self) -> Value<'_> {
-        Value::Listable(self)
-    }
-
-    fn visit(&self, visit: &mut dyn Visit) {
-        for value in self.iter() {
-            visit.visit_value(value.as_value());
-        }
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable> Listable for alloc::collections::LinkedList<T> {
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable + Ord> Valuable for alloc::collections::BinaryHeap<T> {
-    fn as_value(&self) -> Value<'_> {
-        Value::Listable(self)
-    }
-
-    fn visit(&self, visit: &mut dyn Visit) {
-        for value in self.iter() {
-            visit.visit_value(value.as_value());
-        }
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable + Ord> Listable for alloc::collections::BinaryHeap<T> {
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable + Ord> Valuable for alloc::collections::BTreeSet<T> {
-    fn as_value(&self) -> Value<'_> {
-        Value::Listable(self)
-    }
-
-    fn visit(&self, visit: &mut dyn Visit) {
-        for value in self.iter() {
-            visit.visit_value(value.as_value());
-        }
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable + Ord> Listable for alloc::collections::BTreeSet<T> {
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
-    }
-}
-
-#[cfg(feature = "std")]
-impl<T, H> Valuable for std::collections::HashSet<T, H>
-where
-    T: Valuable + Eq + std::hash::Hash,
-    H: std::hash::BuildHasher,
-{
-    fn as_value(&self) -> Value<'_> {
-        Value::Listable(self)
-    }
-
-    fn visit(&self, visit: &mut dyn Visit) {
-        for value in self.iter() {
-            visit.visit_value(value.as_value());
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<T, H> Listable for std::collections::HashSet<T, H>
-where
-    T: Valuable + Eq + std::hash::Hash,
-    H: std::hash::BuildHasher,
-{
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len(), Some(self.len()))
-    }
+collection! {
+    #[cfg(feature = "alloc")]
+    (T: Valuable) alloc::collections::VecDeque<T>,
+    #[cfg(feature = "alloc")]
+    (T: Valuable) alloc::collections::LinkedList<T>,
+    #[cfg(feature = "alloc")]
+    (T: Valuable + Ord) alloc::collections::BinaryHeap<T>,
+    #[cfg(feature = "alloc")]
+    (T: Valuable + Ord) alloc::collections::BTreeSet<T> ,
+    #[cfg(feature = "std")]
+    (T: Valuable + Eq + std::hash::Hash, H: std::hash::BuildHasher) std::collections::HashSet<T, H>,
 }
 
 impl fmt::Debug for dyn Listable + '_ {

--- a/valuable/src/listable.rs
+++ b/valuable/src/listable.rs
@@ -46,6 +46,42 @@ impl<T: Valuable> Listable for alloc::boxed::Box<[T]> {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl<T: Valuable> Valuable for alloc::rc::Rc<[T]> {
+    fn as_value(&self) -> Value<'_> {
+        Value::Listable(self)
+    }
+
+    fn visit(&self, visit: &mut dyn Visit) {
+        T::visit_slice(self, visit);
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Valuable> Listable for alloc::rc::Rc<[T]> {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Valuable> Valuable for alloc::sync::Arc<[T]> {
+    fn as_value(&self) -> Value<'_> {
+        Value::Listable(self)
+    }
+
+    fn visit(&self, visit: &mut dyn Visit) {
+        T::visit_slice(self, visit);
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Valuable> Listable for alloc::sync::Arc<[T]> {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
 impl<T: Valuable, const N: usize> Listable for [T; N] {
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len(), Some(self.len()))
@@ -54,6 +90,114 @@ impl<T: Valuable, const N: usize> Listable for [T; N] {
 
 #[cfg(feature = "alloc")]
 impl<T: Valuable> Listable for alloc::vec::Vec<T> {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Valuable> Valuable for alloc::collections::VecDeque<T> {
+    fn as_value(&self) -> Value<'_> {
+        Value::Listable(self)
+    }
+
+    fn visit(&self, visit: &mut dyn Visit) {
+        for value in self.iter() {
+            visit.visit_value(value.as_value());
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Valuable> Listable for alloc::collections::VecDeque<T> {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Valuable> Valuable for alloc::collections::LinkedList<T> {
+    fn as_value(&self) -> Value<'_> {
+        Value::Listable(self)
+    }
+
+    fn visit(&self, visit: &mut dyn Visit) {
+        for value in self.iter() {
+            visit.visit_value(value.as_value());
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Valuable> Listable for alloc::collections::LinkedList<T> {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Valuable + Ord> Valuable for alloc::collections::BinaryHeap<T> {
+    fn as_value(&self) -> Value<'_> {
+        Value::Listable(self)
+    }
+
+    fn visit(&self, visit: &mut dyn Visit) {
+        for value in self.iter() {
+            visit.visit_value(value.as_value());
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Valuable + Ord> Listable for alloc::collections::BinaryHeap<T> {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Valuable + Ord> Valuable for alloc::collections::BTreeSet<T> {
+    fn as_value(&self) -> Value<'_> {
+        Value::Listable(self)
+    }
+
+    fn visit(&self, visit: &mut dyn Visit) {
+        for value in self.iter() {
+            visit.visit_value(value.as_value());
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Valuable + Ord> Listable for alloc::collections::BTreeSet<T> {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T, H> Valuable for std::collections::HashSet<T, H>
+where
+    T: Valuable + Eq + std::hash::Hash,
+    H: std::hash::BuildHasher,
+{
+    fn as_value(&self) -> Value<'_> {
+        Value::Listable(self)
+    }
+
+    fn visit(&self, visit: &mut dyn Visit) {
+        for value in self.iter() {
+            visit.visit_value(value.as_value());
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T, H> Listable for std::collections::HashSet<T, H>
+where
+    T: Valuable + Eq + std::hash::Hash,
+    H: std::hash::BuildHasher,
+{
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len(), Some(self.len()))
     }

--- a/valuable/src/valuable.rs
+++ b/valuable/src/valuable.rs
@@ -1,4 +1,4 @@
-use crate::{Listable, Slice, Value, Visit};
+use crate::{Slice, Value, Visit};
 
 use core::fmt;
 
@@ -176,48 +176,6 @@ impl Valuable for alloc::string::String {
         Self: Sized,
     {
         visit.visit_slice(Slice::String(slice));
-    }
-}
-
-impl<T: Valuable> Valuable for &'_ [T] {
-    fn as_value(&self) -> Value<'_> {
-        Value::Listable(self as &dyn Listable)
-    }
-
-    fn visit(&self, visit: &mut dyn Visit) {
-        T::visit_slice(self, visit);
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable> Valuable for alloc::boxed::Box<[T]> {
-    fn as_value(&self) -> Value<'_> {
-        Value::Listable(self as &dyn Listable)
-    }
-
-    fn visit(&self, visit: &mut dyn Visit) {
-        T::visit_slice(self, visit);
-    }
-}
-
-impl<T: Valuable, const N: usize> Valuable for [T; N] {
-    fn as_value(&self) -> Value<'_> {
-        Value::Listable(self)
-    }
-
-    fn visit(&self, visit: &mut dyn Visit) {
-        T::visit_slice(self, visit);
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<T: Valuable> Valuable for alloc::vec::Vec<T> {
-    fn as_value(&self) -> Value<'_> {
-        Value::Listable(self)
-    }
-
-    fn visit(&self, visit: &mut dyn Visit) {
-        T::visit_slice(self, visit);
     }
 }
 


### PR DESCRIPTION
remaining [std::collections](https://doc.rust-lang.org/nightly/std/collections/index.html) types and some types:

- `impl<T: Valuable> Listable for Rc<[T]>`
- `impl<T: Valuable> Listable for Arc<[T]>`
- `impl<T: Valuable> Listable for VecDeque<T>`
- `impl<T: Valuable> Listable for LinkedList<T>`
- `impl<T: Valuable + Ord> Listable for BinaryHeap<T>`
- `impl<T: Valuable + Ord> Listable for BTreeSet<T>`
- `impl<T: Valuable + Eq + Hash, H: BuildHasher> Listable for HashSet<T, H>`