### PR TITLE
Fix build error on master

### DIFF
--- a/valuable/src/listable.rs
+++ b/valuable/src/listable.rs
@@ -69,6 +69,7 @@ slice! {
     (T: Valuable) alloc::boxed::Box<[T]>,
     #[cfg(feature = "alloc")]
     (T: Valuable) alloc::rc::Rc<[T]>,
+    #[cfg(not(valuable_no_atomic_cas))]
     #[cfg(feature = "alloc")]
     (T: Valuable) alloc::sync::Arc<[T]>,
     (T: Valuable, const N: usize) [T; N],


### PR DESCRIPTION
`impl Valuable for Arc<[T]>` is added in #13, but when that PR was opened, #12 had not yet been merged, so #13 did not handle targets that do not support atomic CAS.

As a result, the CI of the master branch is currently failing:

```
error[E0433]: failed to resolve: could not find `sync` in `alloc`
  --> valuable/src/listable.rs:73:26
   |
73 |     (T: Valuable) alloc::sync::Arc<[T]>,
   |                          ^^^^ could not find `sync` in `alloc`
```

https://github.com/tokio-rs/valuable/runs/2560992823?check_suite_focus=true

