### PR TITLE
tweak listable visit API

### DIFF
--- a/tests/src/visit_count.rs
+++ b/tests/src/visit_count.rs
@@ -6,7 +6,6 @@ pub struct VisitCount {
     pub visit_named_fields: u32,
     pub visit_unnamed_fields: u32,
     pub visit_primitive_slice: u32,
-    pub visit_item: u32,
     pub visit_entry: u32,
 }
 
@@ -31,10 +30,6 @@ impl Visit for VisitCount {
 
     fn visit_primitive_slice(&mut self, _: Slice<'_>) {
         self.visit_primitive_slice += 1;
-    }
-
-    fn visit_item(&mut self, _: Value<'_>) {
-        self.visit_item += 1;
     }
 
     fn visit_entry(&mut self, _: Value<'_>, _: Value<'_>) {

--- a/tests/src/visit_count.rs
+++ b/tests/src/visit_count.rs
@@ -5,7 +5,8 @@ pub struct VisitCount {
     pub visit_value: u32,
     pub visit_named_fields: u32,
     pub visit_unnamed_fields: u32,
-    pub visit_slice: u32,
+    pub visit_primitive_slice: u32,
+    pub visit_item: u32,
     pub visit_entry: u32,
 }
 
@@ -28,8 +29,12 @@ impl Visit for VisitCount {
         self.visit_unnamed_fields += 1;
     }
 
-    fn visit_slice(&mut self, _: Slice<'_>) {
-        self.visit_slice += 1;
+    fn visit_primitive_slice(&mut self, _: Slice<'_>) {
+        self.visit_primitive_slice += 1;
+    }
+
+    fn visit_item(&mut self, _: Value<'_>) {
+        self.visit_item += 1;
     }
 
     fn visit_entry(&mut self, _: Value<'_>, _: Value<'_>) {

--- a/tests/tests/listable.rs
+++ b/tests/tests/listable.rs
@@ -15,41 +15,10 @@ impl Visit for VisitHello {
 struct VisitList(u32);
 
 impl Visit for VisitList {
-    fn visit_slice(&mut self, slice: Slice<'_>) {
-        let start = self.0;
-
-        test_value_iter(slice.iter(), start);
-        test_value_iter(IntoIterator::into_iter(&slice), start);
-
-        let mut cnt = 0;
-        match slice {
-            Slice::Value(slice) => {
-                for value in slice {
-                    visit_hello(value, self.0);
-                    cnt += 1;
-                    self.0 += 1;
-                }
-            }
-            _ => panic!(),
-        }
-
-        assert_eq!(slice.len(), cnt);
-
-        // Consumes self
-        test_value_iter(IntoIterator::into_iter(slice), start);
+    fn visit_item(&mut self, item: Value<'_>) {
+        visit_hello(&item, self.0);
+        self.0 += 1;
     }
-}
-
-fn test_value_iter<'a>(i: impl Iterator<Item = Value<'a>>, start: u32) {
-    let size_hint = i.size_hint();
-
-    let mut cnt: usize = 0;
-    for (idx, value) in i.enumerate() {
-        visit_hello(&value, start + idx as u32);
-        cnt += 1;
-    }
-
-    assert_eq!(size_hint, (cnt, Some(cnt)));
 }
 
 fn visit_hello(value: &Value<'_>, expect: u32) {
@@ -89,10 +58,7 @@ macro_rules! test_default {
                     let counts = tests::visit_counts(&empty);
                     assert_eq!(
                         counts,
-                        tests::VisitCount {
-                            visit_slice: 1,
-                            ..Default::default()
-                        }
+                        Default::default(),
                     );
                 }
 
@@ -107,7 +73,7 @@ macro_rules! test_default {
                     assert_eq!(
                         counts,
                         tests::VisitCount {
-                            visit_slice: 1,
+                            visit_item: 4,
                             ..Default::default()
                         }
                     );
@@ -128,7 +94,7 @@ macro_rules! test_default {
                     assert_eq!(
                         counts,
                         tests::VisitCount {
-                            visit_slice: 128,
+                            visit_item: 1024,
                             ..Default::default()
                         }
                     );
@@ -149,7 +115,7 @@ macro_rules! test_default {
                     assert_eq!(
                         counts,
                         tests::VisitCount {
-                            visit_slice: 8,
+                            visit_item: 63,
                             ..Default::default()
                         }
                     );
@@ -176,12 +142,27 @@ macro_rules! test_primitive {
     ) => {
         $(
             mod $name {
-                use valuable::*;
+                use super::*;
+
+                fn test_iter<'a>(mut i: impl Iterator<Item = Value<'a>>, expect: &[$ty]) {
+                    assert_eq!(i.size_hint(), (expect.len(), Some(expect.len())));
+                    let mut expect = expect.iter();
+
+                    loop {
+                        match (i.next(), expect.next()) {
+                            (Some(Value::$vvariant(actual)), Some(expect)) => {
+                                assert_eq!(actual, *expect)
+                            }
+                            (None, None) => break,
+                            _ => panic!(),
+                        }
+                    }
+                }
 
                 struct VisitPrimitive(Vec<$ty>);
 
                 impl Visit for VisitPrimitive {
-                    fn visit_slice(&mut self, slice: Slice<'_>) {
+                    fn visit_primitive_slice(&mut self, slice: Slice<'_>) {
                         assert_eq!(slice.len(), self.0.len());
 
                         // fmt::Debug
@@ -198,16 +179,9 @@ macro_rules! test_primitive {
                             _ => panic!(),
                         }
 
-                        let iter = slice.iter();
-                        assert_eq!(iter.size_hint(), (self.0.len(), Some(self.0.len())));
-
-                        // Test iterator
-                        for (idx, value) in iter.enumerate() {
-                            match value {
-                                Value::$vvariant(value) => assert_eq!(self.0[idx], value),
-                                _ => panic!(),
-                            }
-                        }
+                        test_iter(slice.iter(), &self.0);
+                        test_iter(IntoIterator::into_iter(&slice), &self.0);
+                        test_iter(IntoIterator::into_iter(slice), &self.0);
                     }
                 }
 
@@ -218,7 +192,7 @@ macro_rules! test_primitive {
                     assert_eq!(Listable::size_hint(&empty), (0, Some(0)));
 
                     let counts = tests::visit_counts(&empty);
-                    assert_eq!(counts, tests::VisitCount { visit_slice: 1, .. Default::default() });
+                    assert_eq!(counts, tests::VisitCount { visit_primitive_slice: 1, .. Default::default() });
                 }
 
                 #[test]
@@ -229,7 +203,7 @@ macro_rules! test_primitive {
                         assert_eq!(Listable::size_hint(&vec), (len, Some(len)));
 
                         let counts = tests::visit_counts(&vec);
-                        assert_eq!(counts, tests::VisitCount { visit_slice: 1, .. Default::default() });
+                        assert_eq!(counts, tests::VisitCount { visit_primitive_slice: 1, .. Default::default() });
 
                         let mut visit = VisitPrimitive(vec.clone());
                         vec.visit(&mut visit);

--- a/valuable/src/listable.rs
+++ b/valuable/src/listable.rs
@@ -128,10 +128,8 @@ impl fmt::Debug for dyn Listable + '_ {
         }
 
         impl Visit for DebugListable<'_, '_> {
-            fn visit_slice(&mut self, slice: Slice<'_>) {
-                for value in &slice {
-                    self.fmt.entry(&value);
-                }
+            fn visit_item(&mut self, value: Value<'_>) {
+                self.fmt.entry(&value);
             }
         }
 

--- a/valuable/src/listable.rs
+++ b/valuable/src/listable.rs
@@ -128,7 +128,7 @@ impl fmt::Debug for dyn Listable + '_ {
         }
 
         impl Visit for DebugListable<'_, '_> {
-            fn visit_item(&mut self, value: Value<'_>) {
+            fn visit_value(&mut self, value: Value<'_>) {
                 self.fmt.entry(&value);
             }
         }
@@ -136,6 +136,7 @@ impl fmt::Debug for dyn Listable + '_ {
         let mut debug = DebugListable {
             fmt: fmt.debug_list(),
         };
+
         self.visit(&mut debug);
         debug.fmt.finish()
     }

--- a/valuable/src/slice.rs
+++ b/valuable/src/slice.rs
@@ -131,6 +131,5 @@ slice! {
     U64(u64),
     U128(u128),
     Usize(usize),
-    Value(Value<'a>),
     Unit(()),
 }

--- a/valuable/src/valuable.rs
+++ b/valuable/src/valuable.rs
@@ -12,28 +12,8 @@ pub trait Valuable {
     where
         Self: Sized,
     {
-        const N: usize = 8;
-
-        let mut batch: [_; N] = Default::default();
-        let mut curr = 0;
-
-        if slice.is_empty() {
-            visit.visit_slice(Slice::Value(&batch[..0]));
-            return;
-        }
-
-        for v in slice {
-            if curr == N {
-                visit.visit_slice(Slice::Value(&batch[..]));
-                curr = 0;
-            }
-
-            batch[curr] = v.as_value();
-            curr += 1;
-        }
-
-        if curr > 0 {
-            visit.visit_slice(Slice::Value(&batch[..curr]));
+        for item in slice {
+            visit.visit_item(item.as_value());
         }
     }
 }
@@ -102,7 +82,7 @@ macro_rules! valuable {
                 where
                     Self: Sized,
                 {
-                    visit.visit_slice(Slice::$variant(slice));
+                    visit.visit_primitive_slice(Slice::$variant(slice));
                 }
             }
         )*
@@ -186,7 +166,7 @@ impl Valuable for () {
     where
         Self: Sized,
     {
-        visit.visit_slice(Slice::Unit(slice));
+        visit.visit_primitive_slice(Slice::Unit(slice));
     }
 }
 
@@ -203,7 +183,7 @@ impl Valuable for &'_ str {
     where
         Self: Sized,
     {
-        visit.visit_slice(Slice::Str(slice));
+        visit.visit_primitive_slice(Slice::Str(slice));
     }
 }
 
@@ -221,7 +201,7 @@ impl Valuable for alloc::string::String {
     where
         Self: Sized,
     {
-        visit.visit_slice(Slice::String(slice));
+        visit.visit_primitive_slice(Slice::String(slice));
     }
 }
 

--- a/valuable/src/valuable.rs
+++ b/valuable/src/valuable.rs
@@ -13,7 +13,7 @@ pub trait Valuable {
         Self: Sized,
     {
         for item in slice {
-            visit.visit_item(item.as_value());
+            visit.visit_value(item.as_value());
         }
     }
 }

--- a/valuable/src/value.rs
+++ b/valuable/src/value.rs
@@ -84,13 +84,6 @@ impl Valuable for Value<'_> {
     fn visit(&self, visit: &mut dyn Visit) {
         visit.visit_value(self.clone());
     }
-
-    fn visit_slice(slice: &[Self], visit: &mut dyn Visit)
-    where
-        Self: Sized,
-    {
-        visit.visit_slice(Slice::Value(slice));
-    }
 }
 
 impl Default for Value<'_> {

--- a/valuable/src/visit.rs
+++ b/valuable/src/visit.rs
@@ -19,12 +19,8 @@ pub trait Visit {
     /// Visit a slice
     fn visit_primitive_slice(&mut self, slice: Slice<'_>) {
         for value in slice {
-            self.visit_item(value);
+            self.visit_value(value);
         }
-    }
-
-    fn visit_item(&mut self, value: Value<'_>) {
-        drop(value);
     }
 
     // TODO: should we batch visit entries?

--- a/valuable/src/visit.rs
+++ b/valuable/src/visit.rs
@@ -17,8 +17,14 @@ pub trait Visit {
     }
 
     /// Visit a slice
-    fn visit_slice(&mut self, slice: Slice<'_>) {
-        drop(slice);
+    fn visit_primitive_slice(&mut self, slice: Slice<'_>) {
+        for value in slice {
+            self.visit_item(value);
+        }
+    }
+
+    fn visit_item(&mut self, value: Value<'_>) {
+        drop(value);
     }
 
     // TODO: should we batch visit entries?


### PR DESCRIPTION
Instead of always going via visit_slice, a visit_primitive_slice method
is added. Primitive slices go via there. Non-primitive slices call
`visit_item`.