### PR TITLE
flatten `fields` mod

### DIFF
--- a/tests/src/hello_world.rs
+++ b/tests/src/hello_world.rs
@@ -1,4 +1,3 @@
-use valuable::field::*;
 use valuable::*;
 
 #[derive(Default, Debug)]

--- a/tests/tests/enumerable.rs
+++ b/tests/tests/enumerable.rs
@@ -1,4 +1,3 @@
-use valuable::field::*;
 use valuable::*;
 
 #[test]

--- a/tests/tests/structable.rs
+++ b/tests/tests/structable.rs
@@ -1,4 +1,3 @@
-use valuable::field::*;
 use valuable::*;
 
 #[test]

--- a/valuable-derive/src/expand.rs
+++ b/valuable-derive/src/expand.rs
@@ -29,7 +29,7 @@ fn derive_struct(input: &syn::DeriveInput, data: &syn::DataStruct) -> TokenStrea
             struct_def = quote! {
                 ::valuable::StructDef::new_static(
                     #name_literal,
-                    ::valuable::field::Fields::Named(#named_fields_static_name),
+                    ::valuable::Fields::Named(#named_fields_static_name),
                 )
             };
 
@@ -47,7 +47,7 @@ fn derive_struct(input: &syn::DeriveInput, data: &syn::DataStruct) -> TokenStrea
             struct_def = quote! {
                 ::valuable::StructDef::new_static(
                     #name_literal,
-                    ::valuable::field::Fields::Unnamed,
+                    ::valuable::Fields::Unnamed,
                 )
             };
 
@@ -120,7 +120,7 @@ fn derive_enum(input: &syn::DeriveInput, data: &syn::DataEnum) -> TokenStream {
                 variant_defs.push(quote! {
                     ::valuable::VariantDef::new(
                         #variant_name_literal,
-                        ::valuable::field::Fields::Named(#named_fields_static_name),
+                        ::valuable::Fields::Named(#named_fields_static_name),
                     ),
                 });
 
@@ -154,7 +154,7 @@ fn derive_enum(input: &syn::DeriveInput, data: &syn::DataEnum) -> TokenStream {
                 variant_defs.push(quote! {
                     ::valuable::VariantDef::new(
                         #variant_name_literal,
-                        ::valuable::field::Fields::Unnamed,
+                        ::valuable::Fields::Unnamed,
                     ),
                 });
 
@@ -183,7 +183,7 @@ fn derive_enum(input: &syn::DeriveInput, data: &syn::DataEnum) -> TokenStream {
                 variant_defs.push(quote! {
                     ::valuable::VariantDef::new(
                         #variant_name_literal,
-                        ::valuable::field::Fields::Unnamed,
+                        ::valuable::Fields::Unnamed,
                     ),
                 });
 
@@ -261,11 +261,11 @@ fn named_fields_static(name: &Ident, fields: &syn::Fields) -> TokenStream {
     let named_fields = fields.iter().map(|field| {
         let field_name_literal = field.ident.as_ref().unwrap().to_string();
         quote! {
-            ::valuable::field::NamedField::new(#field_name_literal),
+            ::valuable::NamedField::new(#field_name_literal),
         }
     });
     quote! {
-        static #name: &[::valuable::field::NamedField<'static>] = &[
+        static #name: &[::valuable::NamedField<'static>] = &[
             #(#named_fields)*
         ];
     }

--- a/valuable/benches/structable.rs
+++ b/valuable/benches/structable.rs
@@ -1,4 +1,3 @@
-use valuable::field::*;
 use valuable::*;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};

--- a/valuable/examples/hello_world.rs
+++ b/valuable/examples/hello_world.rs
@@ -1,4 +1,3 @@
-use valuable::field::*;
 use valuable::*;
 
 struct HelloWorld {

--- a/valuable/src/lib.rs
+++ b/valuable/src/lib.rs
@@ -17,7 +17,8 @@ extern crate alloc;
 mod enumerable;
 pub use enumerable::{EnumDef, Enumerable, Variant, VariantDef};
 
-pub mod field;
+mod field;
+pub use field::{Fields, NamedField};
 
 mod listable;
 pub use listable::Listable;


### PR DESCRIPTION
Expose `fields::*` types at the root. Given the small number of types,
having a separate module is not worth it.