### PR TITLE
impl valuable traits for mutable reference

### DIFF
--- a/tests/tests/derive.rs
+++ b/tests/tests/derive.rs
@@ -2,6 +2,8 @@
 
 use valuable::Valuable;
 
+use std::collections::HashMap;
+
 #[test]
 fn test_derive_struct() {
     #[derive(Valuable)]
@@ -42,10 +44,6 @@ fn test_derive_enum() {
 
 #[test]
 fn test_derive_mut() {
-    use valuable::Valuable;
-
-    use std::collections::HashMap;
-
     #[derive(Valuable)]
     struct S {
         _f: (),

--- a/tests/tests/derive.rs
+++ b/tests/tests/derive.rs
@@ -39,3 +39,29 @@ fn test_derive_enum() {
     let v = Enum::Unit;
     assert_eq!(format!("{:?}", v.as_value()), r#"Enum::Unit"#);
 }
+
+#[test]
+fn test_derive_mut() {
+    use valuable::Valuable;
+
+    use std::collections::HashMap;
+
+    #[derive(Valuable)]
+    struct S {
+        _f: (),
+    }
+
+    #[derive(Valuable)]
+    enum E {
+        _V,
+    }
+
+    #[derive(Valuable)]
+    struct Test<'a> {
+        string: &'a mut String,
+        list: &'a mut Vec<String>,
+        map: &'a mut HashMap<String, String>,
+        struct_: &'a mut S,
+        enum_: &'a mut E,
+    }
+}

--- a/tests/tests/named_values.rs
+++ b/tests/tests/named_values.rs
@@ -1,4 +1,3 @@
-use valuable::field::*;
 use valuable::*;
 
 #[test]

--- a/valuable/src/enumerable.rs
+++ b/valuable/src/enumerable.rs
@@ -169,6 +169,16 @@ impl<E: ?Sized + Enumerable> Enumerable for &E {
     }
 }
 
+impl<E: ?Sized + Enumerable> Enumerable for &mut E {
+    fn definition(&self) -> EnumDef<'_> {
+        E::definition(&**self)
+    }
+
+    fn variant(&self) -> Variant<'_> {
+        E::variant(&**self)
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl<E: ?Sized + Enumerable> Enumerable for alloc::boxed::Box<E> {
     fn definition(&self) -> EnumDef<'_> {

--- a/valuable/src/listable.rs
+++ b/valuable/src/listable.rs
@@ -12,6 +12,12 @@ impl<L: ?Sized + Listable> Listable for &L {
     }
 }
 
+impl<L: ?Sized + Listable> Listable for &mut L {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        L::size_hint(&**self)
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl<L: ?Sized + Listable> Listable for alloc::boxed::Box<L> {
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/valuable/src/mappable.rs
+++ b/valuable/src/mappable.rs
@@ -12,6 +12,12 @@ impl<M: ?Sized + Mappable> Mappable for &M {
     }
 }
 
+impl<M: ?Sized + Mappable> Mappable for &mut M {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        M::size_hint(&**self)
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl<M: ?Sized + Mappable> Mappable for alloc::boxed::Box<M> {
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/valuable/src/structable.rs
+++ b/valuable/src/structable.rs
@@ -105,6 +105,12 @@ impl<S: ?Sized + Structable> Structable for &S {
     }
 }
 
+impl<S: ?Sized + Structable> Structable for &mut S {
+    fn definition(&self) -> StructDef<'_> {
+        S::definition(&**self)
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl<S: ?Sized + Structable> Structable for alloc::boxed::Box<S> {
     fn definition(&self) -> StructDef<'_> {

--- a/valuable/src/valuable.rs
+++ b/valuable/src/valuable.rs
@@ -20,7 +20,7 @@ pub trait Valuable {
 
 impl<V: ?Sized + Valuable> Valuable for &V {
     fn as_value(&self) -> Value<'_> {
-        (*self).as_value()
+        V::as_value(*self)
     }
 
     fn visit(&self, visit: &mut dyn Visit) {
@@ -28,10 +28,20 @@ impl<V: ?Sized + Valuable> Valuable for &V {
     }
 }
 
+impl<V: ?Sized + Valuable> Valuable for &mut V {
+    fn as_value(&self) -> Value<'_> {
+        V::as_value(&**self)
+    }
+
+    fn visit(&self, visit: &mut dyn Visit) {
+        V::visit(&**self, visit);
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl<V: ?Sized + Valuable> Valuable for alloc::boxed::Box<V> {
     fn as_value(&self) -> Value<'_> {
-        (&**self).as_value()
+        V::as_value(&**self)
     }
 
     fn visit(&self, visit: &mut dyn Visit) {
@@ -42,7 +52,7 @@ impl<V: ?Sized + Valuable> Valuable for alloc::boxed::Box<V> {
 #[cfg(feature = "alloc")]
 impl<V: ?Sized + Valuable> Valuable for alloc::rc::Rc<V> {
     fn as_value(&self) -> Value<'_> {
-        (&**self).as_value()
+        V::as_value(&**self)
     }
 
     fn visit(&self, visit: &mut dyn Visit) {
@@ -54,7 +64,7 @@ impl<V: ?Sized + Valuable> Valuable for alloc::rc::Rc<V> {
 #[cfg(feature = "alloc")]
 impl<V: ?Sized + Valuable> Valuable for alloc::sync::Arc<V> {
     fn as_value(&self) -> Value<'_> {
-        (&**self).as_value()
+        V::as_value(&**self)
     }
 
     fn visit(&self, visit: &mut dyn Visit) {


### PR DESCRIPTION
Without this, we cannot use `derive(Valuable)` on structs such as:

```rust
#[derive(Valuable)]
struct Test<'a> {
    string: &'a mut String,
}
```

```text
error[E0277]: the trait bound `&mut std::string::String: Valuable` is not satisfied
  --> tests/tests/derive.rs:43:10
   |
43 | #[derive(Valuable)]
   |          ^^^^^^^^ the trait `Valuable` is not implemented for `&mut std::string::String`
   |
   = help: the following implementations were found:
             <std::string::String as Valuable>
   = note: `Valuable` is implemented for `&std::string::String`, but not for `&mut std::string::String`
   = note: required by `as_value`
   = note: this error originates in the derive macro `Valuable` (in Nightly builds, run with -Z macro-backtrace for more info)
```

(As for bad diagnostics of valuable-derive, I will fix them in separate PR.)