### PR TITLE
derive: improve diagnostics when field does not implement Valuable

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,3 +12,6 @@ derive = ["valuable/derive"]
 
 [dependencies]
 valuable = { path = "../valuable", default-features = false }
+
+[dev-dependencies]
+trybuild = "1"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,4 +14,5 @@ derive = ["valuable/derive"]
 valuable = { path = "../valuable", default-features = false }
 
 [dev-dependencies]
+rustversion = "1"
 trybuild = "1"

--- a/tests/tests/derive.rs
+++ b/tests/tests/derive.rs
@@ -65,6 +65,7 @@ fn test_derive_mut() {
     }
 }
 
+#[rustversion::attr(not(stable), ignore)]
 #[test]
 fn ui() {
     // Do not require developers to manually set `TRYBUILD=overwrite`.

--- a/tests/tests/derive.rs
+++ b/tests/tests/derive.rs
@@ -3,6 +3,7 @@
 use valuable::Valuable;
 
 use std::collections::HashMap;
+use std::env;
 
 #[test]
 fn test_derive_struct() {
@@ -62,4 +63,15 @@ fn test_derive_mut() {
         struct_: &'a mut S,
         enum_: &'a mut E,
     }
+}
+
+#[test]
+fn ui() {
+    // Do not require developers to manually set `TRYBUILD=overwrite`.
+    if env::var_os("CI").is_none() {
+        env::set_var("TRYBUILD", "overwrite");
+    }
+
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
 }

--- a/tests/tests/ui/not_valuable.rs
+++ b/tests/tests/ui/not_valuable.rs
@@ -1,0 +1,19 @@
+use valuable::Valuable;
+
+struct S;
+
+#[derive(Valuable)]
+struct Struct {
+    f: Option<S>,
+}
+
+#[derive(Valuable)]
+struct Tuple(Option<S>);
+
+#[derive(Valuable)]
+enum Enum {
+    Struct { f: Option<S> },
+    Tuple(Option<S>),
+}
+
+fn main() {}

--- a/tests/tests/ui/not_valuable.stderr
+++ b/tests/tests/ui/not_valuable.stderr
@@ -1,0 +1,39 @@
+error[E0277]: the trait bound `S: Valuable` is not satisfied
+ --> $DIR/not_valuable.rs:7:8
+  |
+7 |     f: Option<S>,
+  |        ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
+  |
+  = note: required because of the requirements on the impl of `Valuable` for `Option<S>`
+  = note: required by `as_value`
+
+error[E0277]: the trait bound `S: Valuable` is not satisfied
+  --> $DIR/not_valuable.rs:11:14
+   |
+11 | struct Tuple(Option<S>);
+   |              ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
+   |
+   = note: required because of the requirements on the impl of `Valuable` for `Option<S>`
+   = note: required by `as_value`
+
+error[E0277]: the trait bound `S: Valuable` is not satisfied
+  --> $DIR/not_valuable.rs:15:17
+   |
+15 |     Struct { f: Option<S> },
+   |                 ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
+   |
+   = note: required because of the requirements on the impl of `Valuable` for `Option<S>`
+   = note: 1 redundant requirements hidden
+   = note: required because of the requirements on the impl of `Valuable` for `&Option<S>`
+   = note: required by `as_value`
+
+error[E0277]: the trait bound `S: Valuable` is not satisfied
+  --> $DIR/not_valuable.rs:16:11
+   |
+16 |     Tuple(Option<S>),
+   |           ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
+   |
+   = note: required because of the requirements on the impl of `Valuable` for `Option<S>`
+   = note: 1 redundant requirements hidden
+   = note: required because of the requirements on the impl of `Valuable` for `&Option<S>`
+   = note: required by `as_value`


### PR DESCRIPTION
follow-up #30

Before:
```text
error[E0277]: the trait bound `S: Valuable` is not satisfied
 --> valuable/examples/not_valuable.rs:5:10
  |
5 | #[derive(Valuable)]
  |          ^^^^^^^^ the trait `Valuable` is not implemented for `S`
  |
  = note: required because of the requirements on the impl of `Valuable` for `Option<S>`
  = note: required by `as_value`
  = note: this error originates in the derive macro `Valuable` (in Nightly builds, run with -Z macro-backtrace for more info)
```
After:
```text
error[E0277]: the trait bound `S: Valuable` is not satisfied
 --> valuable/examples/not_valuable.rs:7:8
  |
7 |     f: Option<S>,
  |        ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
  |
  = note: required because of the requirements on the impl of `Valuable` for `Option<S>`
  = note: required by `as_value`
```