### PR TITLE
Update list of targets that do not support atomic CAS

### DIFF
--- a/valuable/no_atomic.rs
+++ b/valuable/no_atomic.rs
@@ -3,6 +3,8 @@
 
 const NO_ATOMIC_CAS: &[&str] = &[
     "avr-unknown-gnu-atmega328",
+    "bpfeb-unknown-none",
+    "bpfel-unknown-none",
     "msp430-none-elf",
     "riscv32i-unknown-none-elf",
     "riscv32imc-unknown-none-elf",


### PR DESCRIPTION
```console 
$ ./ci/no_atomic.sh
$ git --no-pager diff
diff --git a/valuable/no_atomic.rs b/valuable/no_atomic.rs
index 832a60a..f644a11 100644
--- a/valuable/no_atomic.rs
+++ b/valuable/no_atomic.rs
@@ -3,6 +3,8 @@
 
 const NO_ATOMIC_CAS: &[&str] = &[
     "avr-unknown-gnu-atmega328",
+    "bpfeb-unknown-none",
+    "bpfel-unknown-none",
     "msp430-none-elf",
     "riscv32i-unknown-none-elf",
     "riscv32imc-unknown-none-elf",
$ git checkout -b taiki-e/no-atomic
$ git add valuable/no_atomic.rs
$ git commit -m "Update list of targets that do not support atomic CAS"
```