### PR TITLE
impl valuable traits for more types

### DIFF
--- a/valuable/src/tuplable.rs
+++ b/valuable/src/tuplable.rs
@@ -108,6 +108,36 @@ pub enum TupleDef {
     },
 }
 
+macro_rules! deref {
+    (
+        $(
+            $(#[$attrs:meta])*
+            $ty:ty,
+        )*
+    ) => {
+        $(
+            $(#[$attrs])*
+            impl<T: ?Sized + Tuplable> Tuplable for $ty {
+                fn definition(&self) -> TupleDef {
+                    T::definition(&**self)
+                }
+            }
+        )*
+    };
+}
+
+deref! {
+    &T,
+    &mut T,
+    #[cfg(feature = "alloc")]
+    alloc::boxed::Box<T>,
+    #[cfg(feature = "alloc")]
+    alloc::rc::Rc<T>,
+    #[cfg(not(valuable_no_atomic_cas))]
+    #[cfg(feature = "alloc")]
+    alloc::sync::Arc<T>,
+}
+
 impl Tuplable for () {
     fn definition(&self) -> TupleDef {
         TupleDef::Static { fields: 0 }


### PR DESCRIPTION
- impl `Tuplable` for Box, Rc, Arc, reference, mutable reference
- impl `Visit` for Box and mutable reference (I encountered a case where it was desirable to have this, during writing valuable value pointer macro)
- use macro for more trait impls