### PR TITLE
Implement valuable value pointer

### DIFF
--- a/valuable-derive/Cargo.toml
+++ b/valuable-derive/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0.60", features = ["extra-traits"] }
+syn = { version = "1.0.60", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
 valuable = { path = "../valuable", features = ["derive"] }

--- a/valuable-derive/src/derive.rs
+++ b/valuable-derive/src/derive.rs
@@ -312,7 +312,7 @@ fn allowed_lints() -> TokenStream {
     }
 }
 
-fn respan(tokens: TokenStream, span: &impl ToTokens) -> TokenStream {
+pub(crate) fn respan(tokens: TokenStream, span: &impl ToTokens) -> TokenStream {
     let mut iter = span.to_token_stream().into_iter();
     // `Span` on stable Rust has a limitation that only points to the first
     // token, not the whole tokens. We can work around this limitation by

--- a/valuable-derive/src/lib.rs
+++ b/valuable-derive/src/lib.rs
@@ -1,9 +1,10 @@
-extern crate proc_macro;
+#![warn(rust_2018_idioms, unreachable_pub)]
 
-mod expand;
+mod derive;
+mod pointer;
 
 use proc_macro::TokenStream;
-use syn::parse_macro_input;
+use syn::{parse_macro_input, Error};
 
 /// Derive a `Valuable` implementation for a struct or enum.
 ///
@@ -26,5 +27,12 @@ use syn::parse_macro_input;
 #[proc_macro_derive(Valuable, attributes(valuable))]
 pub fn derive_valuable(input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as syn::DeriveInput);
-    expand::derive_valuable(&mut input).into()
+    derive::derive_valuable(&mut input).into()
+}
+
+#[proc_macro]
+pub fn visit_pointer(input: TokenStream) -> TokenStream {
+    pointer::visit_pointer(input.into())
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
 }

--- a/valuable-derive/src/pointer.rs
+++ b/valuable-derive/src/pointer.rs
@@ -1,0 +1,94 @@
+use std::collections::VecDeque;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{Expr, Result, Token};
+
+use crate::derive::respan;
+
+pub(crate) fn visit_pointer(input: TokenStream) -> Result<TokenStream> {
+    let Input {
+        expr,
+        segments,
+        visit,
+    } = syn::parse2(input)?;
+
+    let segments = segments.iter().map(|segment| match segment {
+        Segment::Member(syn::Member::Named(ident)) => {
+            let literal = ident.to_string();
+            quote! {
+                ::valuable::PointerSegment::Field(#literal),
+            }
+        }
+        Segment::Member(syn::Member::Unnamed(index)) => {
+            quote! {
+                ::valuable::PointerSegment::TupleIndex(#index),
+            }
+        }
+        Segment::Index(expr) => {
+            let expr = respan(quote! { &#expr }, expr);
+            quote! {
+                ::valuable::PointerSegment::Index(
+                    ::valuable::Valuable::as_value(#expr)
+                ),
+            }
+        }
+    });
+
+    let visit_pointer = respan(quote! { ::valuable::Valuable::visit_pointer }, &expr);
+    Ok(quote! {
+        #visit_pointer(
+            &#expr,
+            ::valuable::Pointer::new(&[
+                #(#segments)*
+            ]),
+            &mut #visit,
+        )
+    })
+}
+
+struct Input {
+    expr: Expr,
+    segments: VecDeque<Segment>,
+    visit: Expr,
+}
+
+enum Segment {
+    Member(syn::Member),
+    Index(Box<Expr>),
+}
+
+impl Parse for Input {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let mut chain = input.parse()?;
+        let _: Token![,] = input.parse()?;
+        let visit = input.parse()?;
+        let _: Option<Token![,]> = input.parse()?;
+
+        let mut segments = VecDeque::new();
+        let expr;
+        loop {
+            match chain {
+                Expr::Field(e) => {
+                    chain = *e.base;
+                    segments.push_front(Segment::Member(e.member))
+                }
+                Expr::Index(e) => {
+                    chain = *e.expr;
+                    segments.push_front(Segment::Index(e.index))
+                }
+                e => {
+                    expr = e;
+                    break;
+                }
+            }
+        }
+
+        Ok(Self {
+            expr,
+            segments,
+            visit,
+        })
+    }
+}

--- a/valuable/examples/pointer.rs
+++ b/valuable/examples/pointer.rs
@@ -1,0 +1,53 @@
+// TODO: Change this example to doc example, and add tests.
+
+use valuable::{visit_pointer, Pointer, PointerSegment, Valuable, Value, Visit};
+
+#[derive(Valuable)]
+struct Struct1 {
+    field1: String,
+    field2: Struct2,
+}
+
+#[derive(Valuable)]
+struct Struct2 {
+    field: String,
+}
+
+struct Visitor;
+
+impl Visit for Visitor {
+    fn visit_value(&mut self, value: Value<'_>) {
+        println!("{:?}", value);
+    }
+}
+
+fn main() {
+    let value = Struct1 {
+        field1: "a".to_owned(),
+        field2: Struct2 {
+            field: "b".to_owned(),
+        },
+    };
+
+    let mut visitor = Visitor;
+
+    value.visit_pointer(
+        Pointer::new(&[PointerSegment::Field("field1")]),
+        &mut visitor,
+    );
+    value.visit_pointer(
+        Pointer::new(&[PointerSegment::Field("field2")]),
+        &mut visitor,
+    );
+    value.visit_pointer(
+        Pointer::new(&[
+            PointerSegment::Field("field2"),
+            PointerSegment::Field("field"),
+        ]),
+        &mut visitor,
+    );
+
+    visit_pointer!(value.field1, visitor); // output: "a"
+    visit_pointer!(value.field2, visitor); // output: Struct2 { field: "b" }
+    visit_pointer!(value.field2.field, visitor); // output: "b"
+}

--- a/valuable/src/lib.rs
+++ b/valuable/src/lib.rs
@@ -115,6 +115,9 @@ pub use mappable::Mappable;
 mod named_values;
 pub use named_values::NamedValues;
 
+mod pointer;
+pub use pointer::{Pointer, PointerSegment};
+
 mod slice;
 pub use slice::Slice;
 

--- a/valuable/src/pointer.rs
+++ b/valuable/src/pointer.rs
@@ -1,0 +1,159 @@
+//! Valuable value pointer.
+
+use crate::*;
+
+/// A pointer to the value.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct Pointer<'a> {
+    path: &'a [PointerSegment<'a>],
+}
+
+impl<'a> Pointer<'a> {
+    /// Creates a new `Pointer`.
+    pub const fn new(path: &'a [PointerSegment<'a>]) -> Self {
+        Self { path }
+    }
+
+    /// Returns a path pointed by this pointer.
+    ///
+    /// If this pointer points to the current value, this method returns an empty slice.
+    pub fn path(self) -> &'a [PointerSegment<'a>] {
+        self.path
+    }
+
+    #[must_use]
+    pub fn step(self) -> Self {
+        Self::new(&self.path[1..])
+    }
+}
+
+impl<'a> From<&'a [PointerSegment<'a>]> for Pointer<'a> {
+    fn from(path: &'a [PointerSegment<'a>]) -> Self {
+        Self::new(path)
+    }
+}
+
+/// A segment of a pointer.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum PointerSegment<'a> {
+    /// Access of a named struct field.
+    Field(&'a str),
+    /// Access of an unnamed struct or a tuple field.
+    TupleIndex(usize),
+    /// Indexing of a list or a map.
+    Index(Value<'a>),
+}
+
+pub(crate) fn visit_pointer<V>(value: &V, pointer: Pointer<'_>, visit: &mut dyn Visit)
+where
+    V: ?Sized + Valuable,
+{
+    let value = value.as_value();
+    if pointer.path.is_empty() {
+        visit.visit_value(value);
+        return;
+    }
+
+    let visitor = &mut Visitor {
+        pointer,
+        visit,
+        index: 0,
+    };
+    match (value, pointer.path[0]) {
+        (Value::Listable(l), PointerSegment::Index(..)) => {
+            l.visit(visitor);
+        }
+        (Value::Mappable(m), PointerSegment::Index(..)) => {
+            m.visit(visitor);
+        }
+        (Value::Tuplable(t), PointerSegment::TupleIndex(..)) => {
+            t.visit(visitor);
+        }
+        (Value::Structable(s), PointerSegment::TupleIndex(..))
+            if s.definition().fields().is_unnamed() =>
+        {
+            s.visit(visitor);
+        }
+        (Value::Structable(s), PointerSegment::Field(..)) if s.definition().fields().is_named() => {
+            s.visit(visitor);
+        }
+        (_, p) => {
+            panic!("invalid pointer: {:?},", p)
+        }
+    }
+}
+
+struct Visitor<'a> {
+    pointer: Pointer<'a>,
+    visit: &'a mut dyn Visit,
+    index: usize,
+}
+
+impl Visit for Visitor<'_> {
+    fn visit_value(&mut self, value: Value<'_>) {
+        if let PointerSegment::Index(index) = self.pointer.path[0] {
+            if index.as_usize() == Some(self.index) {
+                value.visit_pointer(self.pointer.step(), self.visit);
+            }
+        }
+        self.index += 1;
+    }
+
+    fn visit_named_fields(&mut self, named_values: &NamedValues<'_>) {
+        if let PointerSegment::Field(name) = self.pointer.path[0] {
+            if let Some(value) = named_values.get_by_name(name) {
+                value.visit_pointer(self.pointer.step(), self.visit);
+            }
+        }
+    }
+
+    fn visit_unnamed_fields(&mut self, values: &[Value<'_>]) {
+        if let PointerSegment::TupleIndex(index) = self.pointer.path[0] {
+            if let Some(value) = values.get(index - self.index) {
+                value.visit_pointer(self.pointer.step(), self.visit);
+            }
+        }
+    }
+
+    fn visit_primitive_slice(&mut self, slice: Slice<'_>) {
+        if let PointerSegment::Index(index) = self.pointer.path[0] {
+            if let Some(index) = index.as_usize() {
+                if let Some(value) = slice.get(index - self.index) {
+                    value.visit_pointer(self.pointer.step(), self.visit);
+                }
+            }
+        }
+        self.index += slice.len();
+    }
+
+    fn visit_entry(&mut self, key: Value<'_>, value: Value<'_>) {
+        if let PointerSegment::Index(index) = self.pointer.path[0] {
+            let matched = match key {
+                Value::Bool(k) => index.as_bool() == Some(k),
+                Value::Char(k) => index.as_char() == Some(k),
+                Value::I8(k) => index.as_i8() == Some(k),
+                Value::I16(k) => index.as_i16() == Some(k),
+                Value::I32(k) => index.as_i32() == Some(k),
+                Value::I64(k) => index.as_i64() == Some(k),
+                Value::I128(k) => index.as_i128() == Some(k),
+                Value::Isize(k) => index.as_isize() == Some(k),
+                Value::U8(k) => index.as_u8() == Some(k),
+                Value::U16(k) => index.as_u16() == Some(k),
+                Value::U32(k) => index.as_u32() == Some(k),
+                Value::U64(k) => index.as_u64() == Some(k),
+                Value::U128(k) => index.as_u128() == Some(k),
+                Value::Usize(k) => index.as_usize() == Some(k),
+                Value::String(k) => index.as_str() == Some(k),
+                #[cfg(feature = "std")]
+                Value::Path(k) => index.as_path() == Some(k),
+                // f32 and f64 are not included because they do not implement `Eq`.
+                _ => false,
+            };
+            if matched {
+                value.visit_pointer(self.pointer.step(), self.visit);
+            }
+        }
+    }
+}

--- a/valuable/src/slice.rs
+++ b/valuable/src/slice.rs
@@ -75,6 +75,17 @@ macro_rules! slice {
                 }
             }
 
+            /// Returns a reference to an element of index.
+            pub fn get(&self, index: usize) -> Option<Value<'_>> {
+                #[allow(unused_doc_comments)]
+                match self {
+                    $(
+                        $(#[$attrs])*
+                        Slice::$variant(s) => s.get(index).map(Valuable::as_value),
+                    )*
+                }
+            }
+
             /// Returns an iterator over the slice.
             ///
             /// # Examples

--- a/valuable/src/valuable.rs
+++ b/valuable/src/valuable.rs
@@ -1,3 +1,4 @@
+use crate::pointer::{self, Pointer};
 use crate::{Slice, Value, Visit};
 
 use core::fmt;
@@ -69,6 +70,11 @@ pub trait Valuable {
         for item in slice {
             visit.visit_value(item.as_value());
         }
+    }
+
+    /// Visit the value pointed by `pointer`.
+    fn visit_pointer(&self, pointer: Pointer<'_>, visit: &mut dyn Visit) {
+        pointer::visit_pointer(self, pointer, visit)
     }
 }
 


### PR DESCRIPTION
### Example

```rust
use valuable::*;

#[derive(Valuable)]
struct Struct1 {
    field1: String,
    field2: Struct2,
}

#[derive(Valuable)]
struct Struct2 {
    field: String,
}

struct Visitor;

impl Visit for Visitor {
    fn visit_value(&mut self, value: Value<'_>) {
        println!("{:?}", value);
    }
}

fn main() {
    let value = Struct1 {
        field1: "a".to_owned(),
        field2: Struct2 {
            field: "b".to_owned(),
        },
    };

    let mut visitor = Visitor;

    visit_pointer!(value.field1, visitor);       // output: "a"
    visit_pointer!(value.field2, visitor);       // output: Struct2 { field: "b" }
    visit_pointer!(value.field2.field, visitor); // output: "b"
}
```

