### PR TITLE
Implement `Valuable` and `Enumerable` for `Result<T, E>`

### DIFF
--- a/valuable/src/enumerable.rs
+++ b/valuable/src/enumerable.rs
@@ -641,3 +641,42 @@ deref! {
     #[cfg(feature = "alloc")]
     alloc::sync::Arc<T>,
 }
+
+static RESULT_VARIANTS: &[VariantDef<'static>] = &[
+    VariantDef::new("Ok", Fields::Unnamed),
+    VariantDef::new("Err", Fields::Unnamed),
+];
+
+impl<T, E> Enumerable for Result<T, E>
+where
+    T: Valuable,
+    E: Valuable,
+{
+    fn definition(&self) -> EnumDef<'_> {
+        EnumDef::new_static("Result", RESULT_VARIANTS)
+    }
+
+    fn variant(&self) -> Variant<'_> {
+        match self {
+            Ok(_) => Variant::Static(&RESULT_VARIANTS[0]),
+            Err(_) => Variant::Static(&RESULT_VARIANTS[1]),
+        }
+    }
+}
+
+impl<T, E> Valuable for Result<T, E>
+where
+    T: Valuable,
+    E: Valuable,
+{
+    fn as_value(&self) -> Value<'_> {
+        Value::Enumerable(self)
+    }
+
+    fn visit(&self, visitor: &mut dyn Visit) {
+        match self {
+            Ok(val) => visitor.visit_unnamed_fields(&[val.as_value()]),
+            Err(val) => visitor.visit_unnamed_fields(&[val.as_value()]),
+        }
+    }
+}


### PR DESCRIPTION
Closes #18

This PR adds `Valuable` and `Enumerable` implementations for 
`Result<T, E>` where `T` and `E` are `Valuable`.

@carllerche's comment in https://github.com/tokio-rs/valuable/issues/18#issue-890512640 suggested
that `Result`s should "flatten" the inner values rather than
implementing `Enumerable`.

However, this PR _does_ implement `Enumerable`. This is because simply
flattening `Result`s to the `Ok` or `Err` value would make it impossible
for the `Visit`or to determine if a given `Result` is an `Ok` or `Err`
value, which seems quite important for some use cases. As I described in
https://github.com/tokio-rs/valuable/issues/18#issuecomment-938905149:

> If the `Err` side of a `Result` is _not_ a `&(dyn std::error::Err + static)`,
> there's no way for the visitor to know if the value is an
> `Ok` or an `Err`.
>
> As a (somewhat contrived) example, if I recorded a `Result<usize, usize>`,
> the visitor would totally lose the information of whether the
> `Result` was an `Ok` or an `Err`...which may actually be the only
> information that we actually want to record.
> 
> Similarly, in some cases, `Result<T, ()>` is a perfectly reasonable
> return type.
>
> IMO, `Result`s _should_ be `Enumerable`, so that the information of
> whether it was `Ok` or `Err` is always retained. But, I could probably
> be convinced otherwise by a sufficiently good argument...

If others disagree that this is the right approach, I'd be happy to
discuss it further, but I thought I'd go ahead and open a PR in the
meantime. :)