### PR TITLE
Fix several clippy lints

### DIFF
--- a/tests/tests/enumerable.rs
+++ b/tests/tests/enumerable.rs
@@ -10,7 +10,7 @@ fn test_manual_static_impl() {
 
     static ENUM_STRUCT_FIELDS: &[NamedField<'static>] = &[NamedField::new("x")];
     static ENUM_VARIANTS: &[VariantDef<'static>] = &[
-        VariantDef::new("Struct", Fields::Named(&ENUM_STRUCT_FIELDS)),
+        VariantDef::new("Struct", Fields::Named(ENUM_STRUCT_FIELDS)),
         VariantDef::new("Tuple", Fields::Unnamed),
         VariantDef::new("Unit", Fields::Unnamed),
     ];

--- a/tests/tests/listable.rs
+++ b/tests/tests/listable.rs
@@ -195,7 +195,18 @@ macro_rules! test_primitive {
                     loop {
                         match (i.next(), expect.next()) {
                             (Some(Value::$vvariant(actual)), Some(expect)) => {
-                                assert_eq!(actual, *expect)
+                                // When testing floating-point values, the
+                                // actual value will be the exact same float
+                                // value as the expected, if everything is
+                                // working correctly. So, it's not strictly
+                                // necessary to use epsilon comparisons here,
+                                // and modifying the macro to use epsilon
+                                // comparisons for floats would make it
+                                // significantly more complex...
+                                #[allow(clippy::float_cmp)]
+                                {
+                                    assert_eq!(actual, *expect)
+                                }
                             }
                             (None, None) => break,
                             _ => panic!(),

--- a/tests/tests/value.rs
+++ b/tests/tests/value.rs
@@ -161,6 +161,9 @@ macro_rules! test_num {
 
         $(
             #[test]
+            // We're not actually using 3.14 as the value of pi, it's just an
+            // arbitrary float...
+            #[allow(clippy::approx_constant)]
             fn $name() {
                 use core::convert::TryFrom;
 
@@ -216,11 +219,17 @@ fn test_char() {
 }
 
 #[test]
+// We're not actually using 3.14 as the value of pi, it's just an
+// arbitrary float...
+#[allow(clippy::approx_constant)]
 fn test_f32() {
     assert_value!(f32: F32, as_f32, eq => 3.1415_f32, -1.234_f32, f32::MAX, f32::MIN);
 }
 
 #[test]
+// We're not actually using 3.14 as the value of pi, it's just an
+// arbitrary float...
+#[allow(clippy::approx_constant)]
 fn test_f64() {
     assert_value!(f64: F64, as_f64, eq => 3.1415_f64, -1.234_f64, f64::MAX, f64::MIN);
 }

--- a/valuable/examples/hello_world.rs
+++ b/valuable/examples/hello_world.rs
@@ -31,7 +31,7 @@ impl Valuable for HelloWorld {
     }
 }
 
-static WORLD_FIELDS: &'static [NamedField<'static>] = &[NamedField::new("answer")];
+static WORLD_FIELDS: &[NamedField<'static>] = &[NamedField::new("answer")];
 
 impl Valuable for World {
     fn as_value(&self) -> Value<'_> {

--- a/valuable/src/slice.rs
+++ b/valuable/src/slice.rs
@@ -75,6 +75,37 @@ macro_rules! slice {
                 }
             }
 
+
+            /// Returns `true` if the slice is not empty.
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// use valuable::Slice;
+            ///
+            /// let slice = Slice::U32(&[1, 1, 2, 3, 5]);
+            /// assert!(!slice.is_empty());
+            /// ```
+            /// ```
+            /// # use valuable::Slice;
+            /// let slice = Slice::U32(&[]);
+            /// assert!(slice.is_empty());
+            /// ```
+            pub fn is_empty(&self) -> bool {
+                self.len() == 0
+            }
+
+            /// Returns the number of elements in the slice
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// use valuable::Slice;
+            ///
+            /// let slice = Slice::U32(&[1, 1, 2, 3, 5]);
+            /// assert_eq!(5, slice.len());
+            /// ```
+
             /// Returns an iterator over the slice.
             ///
             /// # Examples

--- a/valuable/src/slice.rs
+++ b/valuable/src/slice.rs
@@ -95,17 +95,6 @@ macro_rules! slice {
                 self.len() == 0
             }
 
-            /// Returns the number of elements in the slice
-            ///
-            /// # Examples
-            ///
-            /// ```
-            /// use valuable::Slice;
-            ///
-            /// let slice = Slice::U32(&[1, 1, 2, 3, 5]);
-            /// assert_eq!(5, slice.len());
-            /// ```
-
             /// Returns an iterator over the slice.
             ///
             /// # Examples

--- a/valuable/src/value.rs
+++ b/valuable/src/value.rs
@@ -408,11 +408,11 @@ value! {
 
 impl Valuable for Value<'_> {
     fn as_value(&self) -> Value<'_> {
-        self.clone()
+        *self
     }
 
     fn visit(&self, visit: &mut dyn Visit) {
-        visit.visit_value(self.clone());
+        visit.visit_value(*self);
     }
 }
 

--- a/valuable/src/visit.rs
+++ b/valuable/src/visit.rs
@@ -223,7 +223,7 @@ pub trait Visit {
     /// valuable::visit(&my_struct, &mut Print);
     /// ```
     fn visit_named_fields(&mut self, named_values: &NamedValues<'_>) {
-        drop(named_values);
+        let _ = named_values;
     }
 
     /// Visit a struct or enum's unnamed fields.
@@ -267,7 +267,7 @@ pub trait Visit {
     /// valuable::visit(&my_struct, &mut Print);
     /// ```
     fn visit_unnamed_fields(&mut self, values: &[Value<'_>]) {
-        drop(values);
+        let _ = values;
     }
 
     /// Visit a primitive slice.
@@ -359,7 +359,7 @@ pub trait Visit {
     /// valuable::visit(&map, &mut Print);
     /// ```
     fn visit_entry(&mut self, key: Value<'_>, value: Value<'_>) {
-        drop((key, value));
+        let _ = (key, value);
     }
 }
 


### PR DESCRIPTION
This branch contains a number of small fixes for several clippy lints:

* 00f5715 Add `Slice::is_empty()` method

  Clippy lints about types which have a public `len` method but no 
  corresponding `is_empty` method. Therefore, I've added an `is_empty` 
  method that returns `true` if `self.len() > 0`.

  Since this is a new API that we'll have to support, it would also be 
  fine to solve this by _not_ adding the method and just suppressing the 
  warning...but it seems worth having for consistency with the
  underlying slice's methods? And, I don't see how this could really
  pose a forward-compatibility hazard, since `Slice` is...always going
  to be backed by an actual slice...

* fb8c985 don't call `clone` on `Value`, which is `Copy`

* dd3018e fix clippy lints about static lifetimes

  Clippy lints on explicitly using the `'static` lifetime for values in
  a static, and when passing a reference to a reference that is 
  automatically dereferenced (into a single reference) by the compiler. 
  This commit fixes those lints.

* fbc5daa silence clippy warning on approximate values of pi

* c81f5b9 silence warning on non-epsilon float comparisons

  The tests will make assertions that particular values are recorded in
  a particular order. When testing with floating-point values, clippy
  emits a warning that we should be using epsilon comparisons rather
  than bit equality. However, this isn't an issue here, since the tests
  just using float literals, and if the right float is recorded in the
  right order, they will be precisely equal.

* 0e12f69 Fix `clippy::drop_ref` lint

  Clippy doesn't like calls to `std::mem::drop` with references ---
  since the pointed value is not actually dropped. In this case, this
  *is* the correct behavior, but clippy views this as a footgun if the
  user means to actually drop the value behind the reference.

  Here, we're using `drop` to ignore values in no-op default impls for
  trait methods.  I've changed those methods to use `let _` to ignore
  parameters instead. This doesn't trigger the clippy lint and is maybe
  more idiomatic anyway.
