### PR TITLE
fields: Add the number of fields to `Fields::Unnamed`

### DIFF
--- a/tests/tests/enumerable.rs
+++ b/tests/tests/enumerable.rs
@@ -11,8 +11,8 @@ fn test_manual_static_impl() {
     static ENUM_STRUCT_FIELDS: &[NamedField<'static>] = &[NamedField::new("x")];
     static ENUM_VARIANTS: &[VariantDef<'static>] = &[
         VariantDef::new("Struct", Fields::Named(ENUM_STRUCT_FIELDS)),
-        VariantDef::new("Tuple", Fields::Unnamed),
-        VariantDef::new("Unit", Fields::Unnamed),
+        VariantDef::new("Tuple", Fields::Unnamed(1)),
+        VariantDef::new("Unit", Fields::Unnamed(0)),
     ];
 
     impl Enumerable for Enum {
@@ -80,7 +80,7 @@ fn test_manual_dyn_impl() {
         }
 
         fn variant(&self) -> Variant<'_> {
-            Variant::Dynamic(VariantDef::new("MyVariant", Fields::Unnamed))
+            Variant::Dynamic(VariantDef::new("MyVariant", Fields::Unnamed(0)))
         }
     }
 
@@ -109,17 +109,17 @@ fn test_variant_named_field() {
 
 #[test]
 fn test_variant_unnamed_field() {
-    let variant = VariantDef::new("Hello", Fields::Unnamed);
+    let variant = VariantDef::new("Hello", Fields::Unnamed(1));
 
     assert_eq!(variant.name(), "Hello");
-    assert!(matches!(variant.fields(), Fields::Unnamed));
+    assert!(matches!(variant.fields(), Fields::Unnamed(1)));
 }
 
 #[test]
 fn test_enum_def() {
     let fields = [NamedField::new("foo")];
     let a = VariantDef::new("A", Fields::Named(&fields[..]));
-    let b = VariantDef::new("B", Fields::Unnamed);
+    let b = VariantDef::new("B", Fields::Unnamed(1));
     let variants = [a, b];
     let def = EnumDef::new_dynamic("Foo", &variants);
 

--- a/tests/tests/structable.rs
+++ b/tests/tests/structable.rs
@@ -148,17 +148,17 @@ fn test_named_field() {
 
 #[test]
 fn test_fields_unnamed() {
-    let fields = Fields::Unnamed;
+    let fields = Fields::Unnamed(1);
     assert!(fields.is_unnamed());
     assert!(!fields.is_named());
 }
 
 #[test]
 fn test_struct_def() {
-    let def = StructDef::new_static("hello", Fields::Unnamed);
+    let def = StructDef::new_static("hello", Fields::Unnamed(1));
 
     assert_eq!(def.name(), "hello");
-    assert!(matches!(def.fields(), Fields::Unnamed));
+    assert!(matches!(def.fields(), Fields::Unnamed(1)));
     assert!(!def.is_dynamic());
 }
 

--- a/valuable-derive/src/expand.rs
+++ b/valuable-derive/src/expand.rs
@@ -50,10 +50,11 @@ fn derive_struct(input: &syn::DeriveInput, data: &syn::DataStruct) -> TokenStrea
             }
         }
         syn::Fields::Unnamed(_) | syn::Fields::Unit => {
+            let len = data.fields.len();
             struct_def = quote! {
                 ::valuable::StructDef::new_static(
                     #name_literal,
-                    ::valuable::Fields::Unnamed,
+                    ::valuable::Fields::Unnamed(#len),
                 )
             };
 
@@ -172,10 +173,11 @@ fn derive_enum(input: &syn::DeriveInput, data: &syn::DataEnum) -> TokenStream {
             syn::Fields::Unnamed(_) => {
                 let variant_name = &variant.ident;
                 let variant_name_literal = variant_name.to_string();
+                let len = variant.fields.len();
                 variant_defs.push(quote! {
                     ::valuable::VariantDef::new(
                         #variant_name_literal,
-                        ::valuable::Fields::Unnamed,
+                        ::valuable::Fields::Unnamed(#len),
                     ),
                 });
 
@@ -215,7 +217,7 @@ fn derive_enum(input: &syn::DeriveInput, data: &syn::DataEnum) -> TokenStream {
                 variant_defs.push(quote! {
                     ::valuable::VariantDef::new(
                         #variant_name_literal,
-                        ::valuable::Fields::Unnamed,
+                        ::valuable::Fields::Unnamed(0),
                     ),
                 });
 

--- a/valuable-serde/src/lib.rs
+++ b/valuable-serde/src/lib.rs
@@ -375,7 +375,7 @@ impl<S: Serializer> Visit for VisitStaticStruct<S> {
         let (name, serializer) = match mem::replace(self, Self::Tmp) {
             Self::Start {
                 name,
-                fields: Fields::Unnamed,
+                fields: Fields::Unnamed(_),
                 serializer,
             } => (name, serializer),
             mut res @ Self::End(..) => {
@@ -470,7 +470,7 @@ impl<S: Serializer> Visit for VisitStaticEnum<S> {
         };
         let fields = match variant.fields() {
             Fields::Named(fields) => fields,
-            Fields::Unnamed => unreachable!(),
+            Fields::Unnamed(_) => unreachable!(),
         };
         for (i, (_, v)) in named_values.iter().enumerate() {
             if let Err(e) = ser.serialize_field(fields[i].name(), &Serializable(v)) {

--- a/valuable-serde/tests/test.rs
+++ b/valuable-serde/tests/test.rs
@@ -424,7 +424,7 @@ fn test_dyn_struct() {
 
     impl Structable for Unnamed {
         fn definition(&self) -> StructDef<'_> {
-            StructDef::new_dynamic("Unnamed", Fields::Unnamed)
+            StructDef::new_dynamic("Unnamed", Fields::Unnamed(2))
         }
     }
 
@@ -491,7 +491,7 @@ fn test_dyn_enum() {
         fn variant(&self) -> Variant<'_> {
             match self {
                 Self::Named => Variant::Dynamic(VariantDef::new("Named", Fields::Named(&[]))),
-                Self::Unnamed => Variant::Dynamic(VariantDef::new("Named", Fields::Unnamed)),
+                Self::Unnamed => Variant::Dynamic(VariantDef::new("Named", Fields::Unnamed(2))),
             }
         }
     }

--- a/valuable/src/enumerable.rs
+++ b/valuable/src/enumerable.rs
@@ -643,8 +643,8 @@ deref! {
 }
 
 static RESULT_VARIANTS: &[VariantDef<'static>] = &[
-    VariantDef::new("Ok", Fields::Unnamed),
-    VariantDef::new("Err", Fields::Unnamed),
+    VariantDef::new("Ok", Fields::Unnamed(1)),
+    VariantDef::new("Err", Fields::Unnamed(1)),
 ];
 
 impl<T, E> Enumerable for Result<T, E>

--- a/valuable/src/enumerable.rs
+++ b/valuable/src/enumerable.rs
@@ -218,7 +218,7 @@ pub enum EnumDef<'a> {
     ///     }
     ///
     ///     fn variant(&self) -> Variant<'_> {
-    ///         Variant::Dynamic(VariantDef::new(&self.variant, Fields::Unnamed))
+    ///         Variant::Dynamic(VariantDef::new(&self.variant, Fields::Unnamed(0)))
     ///     }
     /// }
     /// ```
@@ -271,7 +271,7 @@ impl<'a> EnumDef<'a> {
     /// use valuable::{EnumDef, Fields, VariantDef};
     ///
     /// static VARIANTS: &[VariantDef<'static>] = &[
-    ///     VariantDef::new("Bar", Fields::Unnamed),
+    ///     VariantDef::new("Bar", Fields::Unnamed(1)),
     /// ];
     ///
     /// let def = EnumDef::new_static( "Foo", VARIANTS);
@@ -294,7 +294,7 @@ impl<'a> EnumDef<'a> {
     ///
     /// let def = EnumDef::new_dynamic(
     ///     "Foo",
-    ///     &[VariantDef::new("Bar", Fields::Unnamed)]
+    ///     &[VariantDef::new("Bar", Fields::Unnamed(1))]
     /// );
     /// ```
     pub const fn new_dynamic(name: &'a str, variants: &'a [VariantDef<'a>]) -> EnumDef<'a> {
@@ -421,7 +421,7 @@ impl<'a> VariantDef<'a> {
     /// ```
     /// use valuable::{Fields, VariantDef};
     ///
-    /// let def = VariantDef::new("Foo", Fields::Unnamed);
+    /// let def = VariantDef::new("Foo", Fields::Unnamed(2));
     /// ```
     pub const fn new(name: &'a str, fields: Fields<'a>) -> VariantDef<'a> {
         VariantDef { name, fields }
@@ -434,7 +434,7 @@ impl<'a> VariantDef<'a> {
     /// ```
     /// use valuable::{Fields, VariantDef};
     ///
-    /// let def = VariantDef::new("Foo", Fields::Unnamed);
+    /// let def = VariantDef::new("Foo", Fields::Unnamed(2));
     /// assert_eq!("Foo", def.name());
     /// ```
     pub fn name(&self) -> &str {
@@ -448,8 +448,8 @@ impl<'a> VariantDef<'a> {
     /// ```
     /// use valuable::{Fields, VariantDef};
     ///
-    /// let def = VariantDef::new("Foo", Fields::Unnamed);
-    /// assert!(matches!(def.fields(), Fields::Unnamed));
+    /// let def = VariantDef::new("Foo", Fields::Unnamed(3));
+    /// assert!(matches!(def.fields(), Fields::Unnamed(_)));
     /// ```
     pub fn fields(&self) -> &Fields<'_> {
         &self.fields
@@ -465,7 +465,7 @@ impl Variant<'_> {
     /// use valuable::{Fields, Variant, VariantDef};
     ///
     /// static VARIANT: &VariantDef<'static> = &VariantDef::new(
-    ///     "Foo", Fields::Unnamed);
+    ///     "Foo", Fields::Unnamed(2));
     ///
     /// let variant = Variant::Static(VARIANT);
     /// assert_eq!("Foo", variant.name());
@@ -507,7 +507,7 @@ impl Variant<'_> {
     /// use valuable::{Fields, Variant, VariantDef};
     ///
     /// static VARIANT: &VariantDef<'static> = &VariantDef::new(
-    ///     "Foo", Fields::Unnamed);
+    ///     "Foo", Fields::Unnamed(1));
     ///
     /// let variant = Variant::Static(VARIANT);
     /// assert!(!variant.is_named_fields());
@@ -538,7 +538,7 @@ impl Variant<'_> {
     /// use valuable::{Fields, Variant, VariantDef};
     ///
     /// static VARIANT: &VariantDef<'static> = &VariantDef::new(
-    ///     "Foo", Fields::Unnamed);
+    ///     "Foo", Fields::Unnamed(1));
     ///
     /// let variant = Variant::Static(VARIANT);
     /// assert!(variant.is_unnamed_fields());

--- a/valuable/src/field.rs
+++ b/valuable/src/field.rs
@@ -5,7 +5,9 @@ pub enum Fields<'a> {
     Named(&'a [NamedField<'a>]),
 
     /// Unnamed (positional) fields or unit
-    Unnamed,
+    ///
+    /// The `usize` value represents the number of fields.
+    Unnamed(usize),
 }
 
 /// A named field
@@ -60,7 +62,72 @@ impl Fields<'_> {
     /// assert!(fields.is_unnamed());
     /// ```
     pub fn is_unnamed(&self) -> bool {
-        matches!(self, Fields::Unnamed)
+        matches!(self, Fields::Unnamed(_))
+    }
+
+    /// Returns the number of fields.
+    ///
+    /// # Examples
+    ///
+    /// Named fields
+    ///
+    /// ```
+    /// use valuable::{Fields, NamedField};
+    ///
+    /// let fields = Fields::Named(&[
+    ///     NamedField::new("alice"),
+    ///     NamedField::new("bob"),
+    /// ]);
+    /// assert_eq!(fields.len(), 2);
+    /// ```
+    ///
+    /// Unnamed fields
+    ///
+    /// ```
+    /// use valuable::Fields;
+    ///
+    /// let fields = Fields::Unnamed(2);
+    /// assert_eq!(fields.len(), 2);
+    /// ```
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Named(names) => names.len(),
+            Self::Unnamed(len) => *len,
+        }
+    }
+
+    /// Returns `true` if this set of fields defines no fields.
+    ///
+    /// # Examples
+    ///
+    /// Named fields
+    ///
+    /// ```
+    /// use valuable::{Fields, NamedField};
+    ///
+    /// let non_empty = Fields::Named(&[
+    ///     NamedField::new("alice"),
+    ///     NamedField::new("bob"),
+    /// ]);
+    /// let empty = Fields::Named(&[]);
+    ///
+    /// assert!(!non_empty.is_empty());
+    /// assert!(empty.is_empty());
+    /// ```
+    ///
+    /// Unnamed fields
+    ///
+    /// ```
+    /// use valuable::Fields;
+    ///
+    /// let non_empty = Fields::Unnamed(2);
+    /// let empty = Fields::Unnamed(0);
+    ///
+    /// assert!(!non_empty.is_empty());
+    /// assert!(empty.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 

--- a/valuable/src/field.rs
+++ b/valuable/src/field.rs
@@ -33,7 +33,7 @@ impl Fields<'_> {
     /// ```
     /// use valuable::Fields;
     ///
-    /// let fields = Fields::Unnamed;
+    /// let fields = Fields::Unnamed(2);
     /// assert!(!fields.is_named());
     /// ```
     pub fn is_named(&self) -> bool {
@@ -58,7 +58,7 @@ impl Fields<'_> {
     /// ```
     /// use valuable::Fields;
     ///
-    /// let fields = Fields::Unnamed;
+    /// let fields = Fields::Unnamed(3);
     /// assert!(fields.is_unnamed());
     /// ```
     pub fn is_unnamed(&self) -> bool {
@@ -74,10 +74,12 @@ impl Fields<'_> {
     /// ```
     /// use valuable::{Fields, NamedField};
     ///
-    /// let fields = Fields::Named(&[
+    /// let fields = &[
     ///     NamedField::new("alice"),
     ///     NamedField::new("bob"),
-    /// ]);
+    /// ];
+    /// let fields = Fields::Named(fields);
+    ///
     /// assert_eq!(fields.len(), 2);
     /// ```
     ///
@@ -105,10 +107,12 @@ impl Fields<'_> {
     /// ```
     /// use valuable::{Fields, NamedField};
     ///
-    /// let non_empty = Fields::Named(&[
+    /// let fields = &[
     ///     NamedField::new("alice"),
     ///     NamedField::new("bob"),
-    /// ]);
+    /// ];
+    /// let non_empty = Fields::Named(fields);
+    ///
     /// let empty = Fields::Named(&[]);
     ///
     /// assert!(!non_empty.is_empty());

--- a/valuable/src/structable.rs
+++ b/valuable/src/structable.rs
@@ -337,7 +337,7 @@ impl<'a> StructDef<'a> {
     /// ```
     /// use valuable::{StructDef, Fields};
     ///
-    /// let def = StructDef::new_static("Foo", Fields::Unnamed);
+    /// let def = StructDef::new_static("Foo", Fields::Unnamed(2));
     /// ```
     pub const fn new_static(name: &'static str, fields: Fields<'static>) -> StructDef<'a> {
         StructDef::Static { name, fields }
@@ -352,7 +352,7 @@ impl<'a> StructDef<'a> {
     /// ```
     /// use valuable::{StructDef, Fields};
     ///
-    /// let def = StructDef::new_dynamic("Foo", Fields::Unnamed);
+    /// let def = StructDef::new_dynamic("Foo", Fields::Unnamed(3));
     /// ```
     pub const fn new_dynamic(name: &'a str, fields: Fields<'a>) -> StructDef<'a> {
         StructDef::Dynamic { name, fields }
@@ -367,7 +367,7 @@ impl<'a> StructDef<'a> {
     /// ```
     /// use valuable::{StructDef, Fields};
     ///
-    /// let def = StructDef::new_static("Foo", Fields::Unnamed);
+    /// let def = StructDef::new_static("Foo", Fields::Unnamed(1));
     /// assert_eq!("Foo", def.name());
     /// ```
     ///
@@ -376,7 +376,7 @@ impl<'a> StructDef<'a> {
     /// ```
     /// use valuable::{StructDef, Fields};
     ///
-    /// let def = StructDef::new_dynamic("Foo", Fields::Unnamed);
+    /// let def = StructDef::new_dynamic("Foo", Fields::Unnamed(2));
     /// assert_eq!("Foo", def.name());
     /// ```
     pub fn name(&self) -> &'a str {
@@ -395,8 +395,8 @@ impl<'a> StructDef<'a> {
     /// ```
     /// use valuable::{StructDef, Fields};
     ///
-    /// let def = StructDef::new_static("Foo", Fields::Unnamed);
-    /// assert!(matches!(def.fields(), Fields::Unnamed));
+    /// let def = StructDef::new_static("Foo", Fields::Unnamed(3));
+    /// assert!(matches!(def.fields(), Fields::Unnamed(_)));
     /// ```
     ///
     /// With a dynamic struct
@@ -404,8 +404,8 @@ impl<'a> StructDef<'a> {
     /// ```
     /// use valuable::{StructDef, Fields};
     ///
-    /// let def = StructDef::new_dynamic("Foo", Fields::Unnamed);
-    /// assert!(matches!(def.fields(), Fields::Unnamed));
+    /// let def = StructDef::new_dynamic("Foo", Fields::Unnamed(1));
+    /// assert!(matches!(def.fields(), Fields::Unnamed(_)));
     /// ```
     pub fn fields(&self) -> &Fields<'a> {
         match self {
@@ -423,7 +423,7 @@ impl<'a> StructDef<'a> {
     /// ```
     /// use valuable::{StructDef, Fields};
     ///
-    /// let def = StructDef::new_static("Foo", Fields::Unnamed);
+    /// let def = StructDef::new_static("Foo", Fields::Unnamed(2));
     /// assert!(def.is_static());
     /// ```
     ///
@@ -432,7 +432,7 @@ impl<'a> StructDef<'a> {
     /// ```
     /// use valuable::{StructDef, Fields};
     ///
-    /// let def = StructDef::new_dynamic("Foo", Fields::Unnamed);
+    /// let def = StructDef::new_dynamic("Foo", Fields::Unnamed(4));
     /// assert!(!def.is_static());
     /// ```
     pub fn is_static(&self) -> bool {
@@ -448,7 +448,7 @@ impl<'a> StructDef<'a> {
     /// ```
     /// use valuable::{StructDef, Fields};
     ///
-    /// let def = StructDef::new_static("Foo", Fields::Unnamed);
+    /// let def = StructDef::new_static("Foo", Fields::Unnamed(1));
     /// assert!(!def.is_dynamic());
     /// ```
     ///
@@ -457,7 +457,7 @@ impl<'a> StructDef<'a> {
     /// ```
     /// use valuable::{StructDef, Fields};
     ///
-    /// let def = StructDef::new_dynamic("Foo", Fields::Unnamed);
+    /// let def = StructDef::new_dynamic("Foo", Fields::Unnamed(1));
     /// assert!(def.is_dynamic());
     /// ```
     pub fn is_dynamic(&self) -> bool {


### PR DESCRIPTION
Closes #36

Currently, there is no way to determine the number of fields in a tuple
struct or tuple-like enum variant without actually visiting the fields.
On the other hand, it _is_ possible to get the number of fields from a
struct or struct-like enum variant, by calling `.len()` on the slice of
`NamedFields` in `Fields::Named`.

It seems like both `Fields::Unnamed` _and_ `Fields::Named` probably
ought to have a way to determine the number of fields. I can imagine
use-cases where (say) a serializer wants to know the number of fields
before actually visiting them, in order to pre-allocate storage, or emit
a length delimiter, or something.

This branch changes `Fields::Unnamed` to store a `usize` number of
fields. It also adds `Fields::len` and `Fields::is_empty` methods to
`Fields`, allowing the length to be accessed without having to
destructure the enum.

Since this adds a field to a public enum, it's a breaking change --- we
probably want to get this in for 1.0.