### PR TITLE
construct `NamedField`s from owned `Strings`

### DIFF
--- a/tests/tests/field.rs
+++ b/tests/tests/field.rs
@@ -1,10 +1,8 @@
 use valuable::NamedField;
 
 fn assert_clone<T: Clone>() {}
-fn assert_copy<T: Copy>() {}
 
 #[test]
 fn is_clone_copy() {
     assert_clone::<NamedField<'static>>();
-    assert_copy::<NamedField<'static>>();
 }

--- a/valuable/src/enumerable.rs
+++ b/valuable/src/enumerable.rs
@@ -494,10 +494,11 @@ impl Variant<'_> {
     /// ```
     /// use valuable::{Fields, NamedField, Variant, VariantDef};
     ///
-    /// static VARIANT: &VariantDef<'static> = &VariantDef::new(
-    ///     "Foo", Fields::Named(&[NamedField::new("hello")]));
+    /// static NAMES: &[NamedField<'static>] = &[NamedField::new("hello")];
+    /// static VARIANT: VariantDef<'static> = VariantDef::new(
+    ///     "Foo", Fields::Named(NAMES));
     ///
-    /// let variant = Variant::Static(VARIANT);
+    /// let variant = Variant::Static(&VARIANT);
     /// assert!(variant.is_named_fields());
     /// ```
     ///
@@ -525,8 +526,9 @@ impl Variant<'_> {
     /// ```
     /// use valuable::{Fields, NamedField, Variant, VariantDef};
     ///
+    /// static NAMES: &[NamedField<'static>] = &[NamedField::new("hello")];
     /// static VARIANT: &VariantDef<'static> = &VariantDef::new(
-    ///     "Foo", Fields::Named(&[NamedField::new("hello")]));
+    ///     "Foo", Fields::Named(NAMES));
     ///
     /// let variant = Variant::Static(VARIANT);
     /// assert!(!variant.is_unnamed_fields());

--- a/valuable/src/field.rs
+++ b/valuable/src/field.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(valuable_no_atomic_cas)))]
 use alloc::{string::String, sync::Arc};
 use core::fmt;
 
@@ -19,7 +19,7 @@ pub struct NamedField<'a>(NamedFieldInner<'a>);
 #[derive(Clone)]
 enum NamedFieldInner<'a> {
     Borrowed(&'a str),
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", not(valuable_no_atomic_cas)))]
     Owned(Arc<str>),
 }
 
@@ -102,7 +102,7 @@ impl<'a> NamedField<'a> {
     /// let field = NamedField::from_string(name);
     /// assert_eq!("hello_world", field.name());
     /// ```
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", not(valuable_no_atomic_cas)))]
     pub fn from_string(name: String) -> NamedField<'static> {
         NamedField(NamedFieldInner::Owned(Arc::from(name)))
     }
@@ -120,7 +120,7 @@ impl<'a> NamedField<'a> {
     pub fn name(&self) -> &str {
         match self.0 {
             NamedFieldInner::Borrowed(name) => name,
-            #[cfg(feature = "alloc")]
+            #[cfg(all(feature = "alloc", not(valuable_no_atomic_cas)))]
             NamedFieldInner::Owned(ref name) => name,
         }
     }
@@ -138,14 +138,14 @@ impl<'a> From<&'a str> for NamedField<'a> {
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(valuable_no_atomic_cas)))]
 impl From<String> for NamedField<'static> {
     fn from(name: String) -> Self {
         Self::from_string(name)
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(valuable_no_atomic_cas)))]
 impl From<Arc<str>> for NamedField<'static> {
     fn from(name: Arc<str>) -> Self {
         Self(NamedFieldInner::Owned(name))

--- a/valuable/src/structable.rs
+++ b/valuable/src/structable.rs
@@ -339,6 +339,16 @@ impl<'a> StructDef<'a> {
     ///
     /// let def = StructDef::new_static("Foo", Fields::Unnamed);
     /// ```
+    ///
+    /// With named fields:
+    /// ```
+    /// use valuable::{StructDef, Fields, NamedField};
+    ///
+    /// static NAMES: &[NamedField<'static>] = &[NamedField::new("hello")];
+    /// static MY_STRUCT: &StructDef<'static> = &StructDef::new_static(
+    ///     "Foo",
+    ///     Fields::Named(NAMES),
+    /// );
     pub const fn new_static(name: &'static str, fields: Fields<'static>) -> StructDef<'a> {
         StructDef::Static { name, fields }
     }


### PR DESCRIPTION
Issue #62 describes a need to construct `Fields::Named` from an owned
set of strings, rather than borrowed ones. This branch adds a
`NamedField::from_string` constructor that returns a `'static`
`NamedField` constructed from an owned `String` value.

The proposed solution in #62 is to use `Cow`s (presumably constructing
`NamedField` from `T: Into<Cow<'a, str>>`). However, we can't easily do
this, as `Cow` is not available without `alloc`, so we'd need two
totally separate internal representations based on whether `alloc` is
enabled. Additionally, we can't have a single `new` constructor taking
`T: Into<Cow<'a, str>>`, for a couple reasons: first, the `new`
constructor is a `const fn`, and `const fn`s can't currently have trait
obunds on generic arguments; second, we can't have the `new` constructor
expose `Cow`, since the constructor would have to have a different type
signature when the `alloc` feature is not enabled.

Instead, I've added an internal enum that's roughly `Cow`-like, and a
`NamedField::from_string` constructor taking a `String` by value. Rather
than directly mimicking `Cow`, though, the owned string case is wrapped
in an `Arc`. This is because `NamedField` currently implements `Clone`
and `Copy`; it's intended to be cheaply clonable. It seems _quite_ bad
to now have a `Clone` that's _either_ a basically free pointer copy or,
sometimes, allocating a string and copying all the bytes in it. Instead,
when a `NamedField` is constructed from a string, we reference count it
so that it can be cloned inexpensively.

I did still remove the `Copy` impl for `NamedField`, since `Arc`s are
not `Copy`. However, if we think it's acceptable for an owned
`NamedField` to perform an arc refcount bump and still implement `Copy`,
I could put it back.

Hopefully, this solves some of the problem from #62. I think we might
also need to do something similar for `Fields::Named`, so that the array
can either be a borrowed slice or an owned
`Vec<NamedField>`/`Box<[NamedField]>`. We can do this with a similar
approach as the one used here, but I wanted to put this PR up first
before starting on that, to make sure it's basically the right
direction.