### PR TITLE
add `doc(cfg(...))` to feature-flagged impls

### DIFF
--- a/valuable/Cargo.toml
+++ b/valuable/Cargo.toml
@@ -27,3 +27,7 @@ criterion = "0.3"
 [[bench]]
 name = "structable"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/valuable/src/cfg.rs
+++ b/valuable/src/cfg.rs
@@ -1,0 +1,12 @@
+macro_rules! feature {
+    (
+        #![$meta:meta]
+        $($item:item)*
+    ) => {
+        $(
+            #[cfg($meta)]
+            #[cfg_attr(docsrs, doc(cfg($meta)))]
+            $item
+        )*
+    }
+}

--- a/valuable/src/enumerable.rs
+++ b/valuable/src/enumerable.rs
@@ -633,13 +633,17 @@ macro_rules! deref {
 deref! {
     &T,
     &mut T,
-    #[cfg(feature = "alloc")]
-    alloc::boxed::Box<T>,
-    #[cfg(feature = "alloc")]
-    alloc::rc::Rc<T>,
-    #[cfg(not(valuable_no_atomic_cas))]
-    #[cfg(feature = "alloc")]
-    alloc::sync::Arc<T>,
+}
+
+feature! {
+    #![feature = "alloc"]
+
+    deref! {
+        alloc::boxed::Box<T>,
+        alloc::rc::Rc<T>,
+        #[cfg(not(valuable_no_atomic_cas))]
+        alloc::sync::Arc<T>,
+    }
 }
 
 static RESULT_VARIANTS: &[VariantDef<'static>] = &[

--- a/valuable/src/lib.rs
+++ b/valuable/src/lib.rs
@@ -96,9 +96,13 @@
 //! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[macro_use]
+mod cfg;
 
 mod enumerable;
 pub use enumerable::{EnumDef, Enumerable, Variant, VariantDef};
@@ -133,5 +137,8 @@ pub use value::Value;
 mod visit;
 pub use visit::{visit, Visit};
 
-#[cfg(feature = "derive")]
-pub use valuable_derive::*;
+feature! {
+    #![feature = "derive"]
+
+    pub use valuable_derive::*;
+}

--- a/valuable/src/structable.rs
+++ b/valuable/src/structable.rs
@@ -486,11 +486,15 @@ macro_rules! deref {
 deref! {
     &T,
     &mut T,
-    #[cfg(feature = "alloc")]
-    alloc::boxed::Box<T>,
-    #[cfg(feature = "alloc")]
-    alloc::rc::Rc<T>,
-    #[cfg(not(valuable_no_atomic_cas))]
-    #[cfg(feature = "alloc")]
-    alloc::sync::Arc<T>,
+}
+
+feature! {
+    #![feature = "alloc"]
+
+    deref! {
+        alloc::boxed::Box<T>,
+        alloc::rc::Rc<T>,
+        #[cfg(not(valuable_no_atomic_cas))]
+        alloc::sync::Arc<T>,
+    }
 }

--- a/valuable/src/tuplable.rs
+++ b/valuable/src/tuplable.rs
@@ -129,13 +129,17 @@ macro_rules! deref {
 deref! {
     &T,
     &mut T,
-    #[cfg(feature = "alloc")]
-    alloc::boxed::Box<T>,
-    #[cfg(feature = "alloc")]
-    alloc::rc::Rc<T>,
-    #[cfg(not(valuable_no_atomic_cas))]
-    #[cfg(feature = "alloc")]
-    alloc::sync::Arc<T>,
+}
+
+feature! {
+    #![feature = "alloc"]
+
+    deref!{
+        alloc::boxed::Box<T>,
+        alloc::rc::Rc<T>,
+        #[cfg(not(valuable_no_atomic_cas))]
+        alloc::sync::Arc<T>,
+    }
 }
 
 impl Tuplable for () {

--- a/valuable/src/value.rs
+++ b/valuable/src/value.rs
@@ -311,6 +311,7 @@ value! {
     /// let v = Value::Path(path);
     /// ```
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     Path(&'a std::path::Path),
 
     /// A Rust error value
@@ -325,6 +326,7 @@ value! {
     /// let v = Value::Error(&err);
     /// ```
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     Error(&'a (dyn std::error::Error +'static)),
 
     /// A Rust list value
@@ -553,6 +555,7 @@ macro_rules! convert {
             /// assert!(Value::Bool(true).as_path().is_none());
             /// ```
             #[cfg(feature = "std")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
             pub fn as_path(&self) -> Option<&std::path::Path> {
                 match *self {
                     Value::Path(v) => Some(v),
@@ -574,13 +577,13 @@ macro_rules! convert {
             /// assert!(Value::Bool(true).as_error().is_none());
             /// ```
             #[cfg(feature = "std")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
             pub fn as_error(&self) -> Option<&(dyn std::error::Error + 'static)> {
                 match *self {
                     Value::Error(v) => Some(v),
                     _ => None,
                 }
             }
-
 
             /// Return a `&dyn Listable` representation of `self`, if possible.
             ///


### PR DESCRIPTION
Currently, feature-flagged public APIs will not be documented as
requiring feature flags. This branch adds `#[doc(cfg(...))]` to all
feature-flagged APIs.

For the most part, this is done using the `feature!` macro lifted from
Tokio:
https://github.com/tokio-rs/tokio/blob/8943e8aeef0b33f371d6dc69f62b38da390b5d5f/tokio/src/macros/cfg.rs#L3-L14

In a couple of places, though, the feature-flagged thing is in a
position other than item position, so in that case, it was necessary to
just paste the attribute...

Signed-off-by: Eliza Weisman <eliza@buoyant.io>