### PR TITLE
Enable doc_cfg and doc_auto_cfg features on docs.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,4 @@ jobs:
         run: rustup update nightly && rustup default nightly
       - run: cargo doc --no-deps --all-features
         env:
-          RUSTDOCFLAGS: -Dwarnings
+          RUSTDOCFLAGS: -Dwarnings --cfg docsrs

--- a/valuable/Cargo.toml
+++ b/valuable/Cargo.toml
@@ -27,3 +27,7 @@ criterion = "0.3"
 [[bench]]
 name = "structable"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/valuable/src/lib.rs
+++ b/valuable/src/lib.rs
@@ -96,6 +96,15 @@
 //! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg, doc_cfg_hide))]
+#![cfg_attr(
+    docsrs,
+    doc(cfg_hide(
+        not(valuable_no_atomic_cas),
+        not(valuable_no_atomic),
+        not(valuable_no_atomic_64)
+    ))
+)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -134,4 +143,4 @@ mod visit;
 pub use visit::{visit, Visit};
 
 #[cfg(feature = "derive")]
-pub use valuable_derive::*;
+pub use valuable_derive::Valuable;


### PR DESCRIPTION
Replaces #74.


refs: https://github.com/rust-lang/rust/pull/89596, https://github.com/rust-lang/rust/pull/90502
Closes: #74

### Screenshots

<img width="659" alt="doc_cfg1" src="https://user-images.githubusercontent.com/43724913/147620950-cdc28236-f3f0-464f-a90a-abb7e4723261.png">
<img width="659" alt="doc_cfg2" src="https://user-images.githubusercontent.com/43724913/147620959-73188c85-c764-4352-9d42-43c61138297b.png">
<img width="659" alt="doc_cfg3" src="https://user-images.githubusercontent.com/43724913/147620967-1b59d195-cf3f-4dc6-9bd9-0c2ff70e634e.png">
<img width="659" alt="doc_cfg4" src="https://user-images.githubusercontent.com/43724913/147620973-957174a1-0c5e-498a-99d5-dbffb91db6e9.png">
