### PR TITLE
Fix broken doc link

### DIFF
--- a/valuable/src/mappable.rs
+++ b/valuable/src/mappable.rs
@@ -6,7 +6,7 @@ use core::fmt;
 ///
 /// Implemented by [`Valuable`] types that have a map-like shape. This includes
 /// [`HashMap`] and other Rust [collection] types. Values that implement
-/// `Mappable` must return [`Value::Mappable`] from their [`Value::as_value`]
+/// `Mappable` must return [`Value::Mappable`] from their [`Valuable::as_value`]
 /// implementation.
 ///
 /// [collection]: https://doc.rust-lang.org/stable/std/collections/index.html


### PR DESCRIPTION
Fixes CI failure: https://github.com/tokio-rs/valuable/runs/4770047852?check_suite_focus=true

```
warning: unresolved link to `Value::as_value`
 --> valuable/src/mappable.rs:9:61
  |
9 | /// `Mappable` must return [`Value::Mappable`] from their [`Value::as_value`]
  |                                                             ^^^^^^^^^^^^^^^ the enum `Value` has no variant or associated item named `as_value`
  |
  = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
```