### PR TITLE
Make implementation Valuable for HashMap more generic.

### DIFF
--- a/valuable/src/mappable.rs
+++ b/valuable/src/mappable.rs
@@ -129,7 +129,7 @@ deref! {
 }
 
 #[cfg(feature = "std")]
-impl<K: Valuable, V: Valuable> Valuable for std::collections::HashMap<K, V> {
+impl<K: Valuable, V: Valuable, S> Valuable for std::collections::HashMap<K, V, S> {
     fn as_value(&self) -> Value<'_> {
         Value::Mappable(self)
     }
@@ -142,7 +142,7 @@ impl<K: Valuable, V: Valuable> Valuable for std::collections::HashMap<K, V> {
 }
 
 #[cfg(feature = "std")]
-impl<K: Valuable, V: Valuable> Mappable for std::collections::HashMap<K, V> {
+impl<K: Valuable, V: Valuable, S> Mappable for std::collections::HashMap<K, V, S> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter().size_hint()
     }


### PR DESCRIPTION
With this MR I be able to use `valuable` for `HashMap` with different hasher.