### PR TITLE
Add clippy::indexing_slicing to the list of ignored lints

### DIFF
--- a/valuable-derive/src/expand.rs
+++ b/valuable-derive/src/expand.rs
@@ -311,6 +311,7 @@ fn allowed_lints() -> TokenStream {
         #[allow(non_upper_case_globals)]
         #[allow(clippy::unknown_clippy_lints)]
         #[allow(clippy::used_underscore_binding)]
+        #[allow(clippy::indexing_slicing)]
     }
 }
 


### PR DESCRIPTION
I am currently using `valuable` on a project that has most clippy lints enabled, and it is showing warnings because it uses direct array indexing to access the fields on the generated macro code. Unfortunately, there's no way to ignore it directly, as it gets "imported" to application code on macro expansion.

This PR adds `clippy::indexing_slicing` to the listing of ignored lints.