### PR TITLE
Migrate to Rust 2021

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 2 * * 0'
 
 env:
   RUSTFLAGS: -Dwarnings

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tests"
 version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 publish = false
 

--- a/tests/tests/listable.rs
+++ b/tests/tests/listable.rs
@@ -281,7 +281,7 @@ macro_rules! test_primitive {
 
 test_primitive! {
     test_bool, Bool(Value::Bool): bool => |x| { x % 2 == 0 };
-    test_char, Char(Value::Char): char => |x| { core::convert::TryFrom::try_from(x as u32).unwrap_or('f') };
+    test_char, Char(Value::Char): char => |x| { TryFrom::try_from(x as u32).unwrap_or('f') };
     test_f32, F32(Value::F32): f32 => |x| { x as f32 };
     test_f64, F64(Value::F64): f64 => |x| { x as f64 };
     test_i8, I8(Value::I8): i8 => |x| { x as i8 };

--- a/tests/tests/ui/not_valuable.stderr
+++ b/tests/tests/ui/not_valuable.stderr
@@ -8,14 +8,14 @@ error[E0277]: the trait bound `S: Valuable` is not satisfied
   |        ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
   |
   = help: the following other types implement trait `Valuable`:
-            &T
-            &[T]
-            &mut T
-            &std::path::Path
-            &str
-            ()
-            (T0, T1)
-            (T0, T1, T2)
+            bool
+            char
+            isize
+            i8
+            i16
+            i32
+            i64
+            i128
           and $N others
   = note: required for `Option<S>` to implement `Valuable`
 
@@ -28,14 +28,14 @@ error[E0277]: the trait bound `S: Valuable` is not satisfied
    |              ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
    |
    = help: the following other types implement trait `Valuable`:
-             &T
-             &[T]
-             &mut T
-             &std::path::Path
-             &str
-             ()
-             (T0, T1)
-             (T0, T1, T2)
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
            and $N others
    = note: required for `Option<S>` to implement `Valuable`
 
@@ -49,14 +49,14 @@ error[E0277]: the trait bound `S: Valuable` is not satisfied
    |                 ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
    |
    = help: the following other types implement trait `Valuable`:
-             &T
-             &[T]
-             &mut T
-             &std::path::Path
-             &str
-             ()
-             (T0, T1)
-             (T0, T1, T2)
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
            and $N others
    = note: required for `Option<S>` to implement `Valuable`
    = note: 1 redundant requirement hidden
@@ -72,14 +72,14 @@ error[E0277]: the trait bound `S: Valuable` is not satisfied
    |           ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
    |
    = help: the following other types implement trait `Valuable`:
-             &T
-             &[T]
-             &mut T
-             &std::path::Path
-             &str
-             ()
-             (T0, T1)
-             (T0, T1, T2)
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
            and $N others
    = note: required for `Option<S>` to implement `Valuable`
    = note: 1 redundant requirement hidden

--- a/tests/tests/value.rs
+++ b/tests/tests/value.rs
@@ -122,8 +122,6 @@ macro_rules! ints {
     (
         $( $n:expr ),*
      ) => {{
-        use core::convert::TryFrom;
-
         vec![
             $(
                 <u8>::try_from($n).ok().map(Value::from),
@@ -165,8 +163,6 @@ macro_rules! test_num {
             // arbitrary float...
             #[allow(clippy::approx_constant)]
             fn $name() {
-                use core::convert::TryFrom;
-
                 let mut valid = vec![];
                 let mut invalid = vec![
                     Value::from(true),

--- a/valuable-derive/Cargo.toml
+++ b/valuable-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "valuable-derive"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 rust-version = "1.56"
 description = "Macros for the `valuable` crate."

--- a/valuable-serde/Cargo.toml
+++ b/valuable-serde/Cargo.toml
@@ -2,7 +2,7 @@
 name = "valuable-serde"
 version = "0.1.0"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 description = "`serde::Serialize` implementation for `Valuable` types."
 rust-version = "1.56"

--- a/valuable/Cargo.toml
+++ b/valuable/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "valuable"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 rust-version = "1.56"
 readme = "../README.md"

--- a/valuable/src/value.rs
+++ b/valuable/src/value.rs
@@ -502,7 +502,6 @@ macro_rules! convert {
                 $(#[$attrs])*
                 pub fn $as(&self) -> Option<$ty> {
                     use Value::*;
-                    use core::convert::TryInto;
 
                     match *self {
                         I8(v) => v.try_into().ok(),


### PR DESCRIPTION
Our MSRV is 1.56 that Rust 2021 was stabilized.

(The first commit is a CI fix from #119)