### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update stable
-      - run: cargo fmt --all -- --check
+      - run: cargo fmt --all --check
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
               echo "::set-output name=success::false"
           fi
         if: github.repository_owner == 'tokio-rs' && github.event_name == 'schedule'
-      - uses: peter-evans/create-pull-request@v3
+      - uses: peter-evans/create-pull-request@v5
         with:
           title: Update no_atomic.rs
           body: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  minrust: '1.56'
 
 jobs:
   test:
@@ -29,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update ${{ env.minrust }} && rustup default ${{ env.minrust }}
-      - run: cargo check --workspace --all-features
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack check --workspace --all-features --ignore-private --rust-version
 
   no-std:
     strategy:


### PR DESCRIPTION
- Update peter-evans/create-pull-request action to v5
- Remove no longer needed argument for cargo fmt
- Use cargo-hack's --rust-version flag for minrust job
  This respects rust-version field in Cargo.toml, so it removes the need to manage MSRV in both the CI file and Cargo.toml.