### PR TITLE
feat(DeriveAttribute) Implement derive macro attribute for format

### DIFF
--- a/tests/tests/derive.rs
+++ b/tests/tests/derive.rs
@@ -205,3 +205,29 @@ fn ui() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");
 }
+
+#[test]
+fn test_format_not_valuable() {
+    #[derive(Debug)]
+    struct NotValuable;
+
+    #[derive(Valuable)]
+    struct S {
+        f1: (),
+        #[valuable(format = "{:?}")]
+        f2: NotValuable,
+        f3: (),
+    }
+
+    #[derive(Valuable)]
+    struct T((), #[valuable(format = "{:?}")] NotValuable, ());
+
+    let s = Structable::definition(&S {
+        f1: (),
+        f2: NotValuable,
+        f3: (),
+    });
+    assert!(matches!(s.fields(), Fields::Named(f) if f.len() == 3));
+    let s = Structable::definition(&T((), NotValuable, ()));
+    assert!(matches!(s.fields(), Fields::Unnamed(f) if *f == 3));
+}

--- a/valuable-derive/src/expand.rs
+++ b/valuable-derive/src/expand.rs
@@ -101,11 +101,18 @@ fn derive_struct(
                 .iter()
                 .enumerate()
                 .filter(|(i, _)| !field_attrs[*i].skip())
-                .map(|(_, field)| {
+                .map(|(i, field)| {
                     let f = field.ident.as_ref();
-                    let tokens = quote! {
-                        &self.#f
+                    let tokens = if let Some(format_str) = field_attrs[i].format() {
+                        quote! {
+                            &format!(#format_str, self.#f)
+                        }
+                    } else {
+                        quote! {
+                            &self.#f
+                        }
                     };
+
                     respan(tokens, &field.ty)
                 });
             visit_fields = quote! {
@@ -125,8 +132,14 @@ fn derive_struct(
                 .filter(|(i, _)| !field_attrs[*i].skip())
                 .map(|(i, field)| {
                     let index = syn::Index::from(i);
-                    let tokens = quote! {
-                        &self.#index
+                    let tokens = if let Some(format_str) = field_attrs[i].format() {
+                        quote! {
+                            &format!(#format_str, self.#index)
+                        }
+                    } else {
+                        quote! {
+                            &self.#index
+                        }
                     };
                     respan(tokens, &field.ty)
                 })


### PR DESCRIPTION
Build on the newly-introduced derive-attribute framework to allow fields in structs to be written to the final value as a formatted string instead of their actual value. This allows for types that don't (and can't or won't) implement `Valuable` to be included in the value