### PR TITLE
Prepare valuable, valuable-derive, and valuable-serde 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.1 (2025-01-09)
+
+- Make `Valuable` implementation for `HashMap` more generic (#112)
+- Bump MSRV to 1.56 (#118)
+- derive: update syn to 2.0 (#118)
+- derive: implement `#[valuable]` attributes (#75)
+- derive: use `#[automatically_derived]` on generated impls to improve coverage support (#136)
+
 # 0.1.0 (2022-01-03)
 
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.1 (2025-01-09)
+# 0.1.1 (2025-01-17)
 
 - Make `Valuable` implementation for `HashMap` more generic (#112)
 - Bump MSRV to 1.56 (#118)

--- a/tests/tests/ui/not_valuable.stderr
+++ b/tests/tests/ui/not_valuable.stderr
@@ -5,7 +5,7 @@ error[E0277]: the trait bound `S: Valuable` is not satisfied
   |          -------- required by a bound introduced by this call
 6 | struct Struct {
 7 |     f: Option<S>,
-  |        ^^^^^^^^^ the trait `Valuable` is not implemented for `S`, which is required by `Option<S>: Valuable`
+  |        ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
   |
   = help: the following other types implement trait `Valuable`:
             &T
@@ -25,7 +25,7 @@ error[E0277]: the trait bound `S: Valuable` is not satisfied
 10 | #[derive(Valuable)]
    |          -------- required by a bound introduced by this call
 11 | struct Tuple(Option<S>);
-   |              ^^^^^^^^^ the trait `Valuable` is not implemented for `S`, which is required by `Option<S>: Valuable`
+   |              ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
    |
    = help: the following other types implement trait `Valuable`:
              &T
@@ -46,7 +46,7 @@ error[E0277]: the trait bound `S: Valuable` is not satisfied
    |          -------- required by a bound introduced by this call
 14 | enum Enum {
 15 |     Struct { f: Option<S> },
-   |                         ^ the trait `Valuable` is not implemented for `S`, which is required by `&Option<S>: Valuable`
+   |                         ^ the trait `Valuable` is not implemented for `S`
    |
    = help: the following other types implement trait `Valuable`:
              &T
@@ -69,7 +69,7 @@ error[E0277]: the trait bound `S: Valuable` is not satisfied
    |          -------- required by a bound introduced by this call
 ...
 16 |     Tuple(Option<S>),
-   |                   ^ the trait `Valuable` is not implemented for `S`, which is required by `&Option<S>: Valuable`
+   |                   ^ the trait `Valuable` is not implemented for `S`
    |
    = help: the following other types implement trait `Valuable`:
              &T

--- a/valuable-derive/Cargo.toml
+++ b/valuable-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "valuable-derive"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 rust-version = "1.56"

--- a/valuable-serde/CHANGELOG.md
+++ b/valuable-serde/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1 (2025-01-09)
+
+- Serialize `dyn Error` Values as a struct with fields for sources (#92)
+
 # 0.1.0 (2022-01-26)
 
 - Initial release

--- a/valuable-serde/CHANGELOG.md
+++ b/valuable-serde/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.1 (2025-01-09)
+# 0.1.1 (2025-01-17)
 
 - Serialize `dyn Error` Values as a struct with fields for sources (#92)
 

--- a/valuable-serde/Cargo.toml
+++ b/valuable-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "valuable-serde"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/valuable/Cargo.toml
+++ b/valuable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 rust-version = "1.56"
@@ -33,7 +33,7 @@ std = ["alloc"]
 alloc = []
 
 [dependencies]
-valuable-derive = { version = "0.1.0", optional = true, path = "../valuable-derive" }
+valuable-derive = { version = "=0.1.1", optional = true, path = "../valuable-derive" }
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
## Changes

### valuable, valuable-derive 0.1.1

- Make `Valuable` implementation for `HashMap` more generic (#112)
- Bump MSRV to 1.56 (#118)
- derive: update syn to 2.0 (#118)
- derive: implement `#[valuable]` attributes (#75)
- derive: use `#[automatically_derived]` on generated impls to improve coverage support (#136)

### valuable-serde 0.1.1

- Serialize `dyn Error` Values as a struct with fields for sources (#92)

---

Except for https://crates.io/crates/valuable, the core team does not have the permission to publish these crates, so I cannot publish them at this time:


- [x] https://crates.io/crates/valuable-derive
  @carllerche: Could you give the core team permission to publish this crate?
- [x] https://crates.io/crates/valuable-serde
  @hawkw: Could you give the core team permission to publish this crate?

---

Closes #135 