### PR TITLE
feat(derive): add `crate` attribute for re-export scenarios

### DIFF
--- a/tests/tests/derive.rs
+++ b/tests/tests/derive.rs
@@ -194,6 +194,81 @@ fn test_transparent() {
     assert!(matches!(Valuable::as_value(&T('a')), Value::Char('a')));
 }
 
+#[test]
+fn test_crate_attr_struct() {
+    // Simulate a re-export scenario by using `crate = "valuable"`
+    mod reexport {
+        pub use valuable::*;
+    }
+
+    #[derive(reexport::Valuable)]
+    #[valuable(crate = "reexport")]
+    struct MyStruct {
+        x: &'static str,
+    }
+
+    #[derive(reexport::Valuable)]
+    #[valuable(crate = "reexport")]
+    struct MyTuple(u8);
+
+    #[derive(reexport::Valuable)]
+    #[valuable(crate = "reexport")]
+    struct MyUnit;
+
+    #[derive(reexport::Valuable)]
+    #[valuable(crate = "reexport", transparent)]
+    struct MyTransparent(u8);
+
+    let v = MyStruct { x: "hello" };
+    assert_eq!(
+        format!("{:?}", reexport::Valuable::as_value(&v)),
+        r#"MyStruct { x: "hello" }"#
+    );
+    let v = MyTuple(42);
+    assert_eq!(
+        format!("{:?}", reexport::Valuable::as_value(&v)),
+        "MyTuple(42)"
+    );
+    let v = MyUnit;
+    assert_eq!(format!("{:?}", reexport::Valuable::as_value(&v)), "MyUnit");
+    let v = MyTransparent(7);
+    assert!(matches!(
+        reexport::Valuable::as_value(&v),
+        reexport::Value::U8(7)
+    ));
+}
+
+#[test]
+fn test_crate_attr_enum() {
+    mod reexport {
+        pub use valuable::*;
+    }
+
+    #[derive(reexport::Valuable)]
+    #[valuable(crate = "reexport")]
+    enum MyEnum {
+        Named { x: &'static str },
+        Unnamed(u8),
+        Unit,
+    }
+
+    let v = MyEnum::Named { x: "world" };
+    assert_eq!(
+        format!("{:?}", reexport::Valuable::as_value(&v)),
+        r#"MyEnum::Named { x: "world" }"#
+    );
+    let v = MyEnum::Unnamed(1);
+    assert_eq!(
+        format!("{:?}", reexport::Valuable::as_value(&v)),
+        "MyEnum::Unnamed(1)"
+    );
+    let v = MyEnum::Unit;
+    assert_eq!(
+        format!("{:?}", reexport::Valuable::as_value(&v)),
+        "MyEnum::Unit"
+    );
+}
+
 #[rustversion::attr(not(stable), ignore)]
 #[test]
 fn ui() {

--- a/tests/tests/ui/not_valuable.stderr
+++ b/tests/tests/ui/not_valuable.stderr
@@ -5,8 +5,13 @@ error[E0277]: the trait bound `S: Valuable` is not satisfied
   |          -------- required by a bound introduced by this call
 6 | struct Struct {
 7 |     f: Option<S>,
-  |        ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
+  |        ^^^^^^^^^ unsatisfied trait bound
   |
+help: the trait `Valuable` is not implemented for `S`
+ --> tests/ui/not_valuable.rs:3:1
+  |
+3 | struct S;
+  | ^^^^^^^^
   = help: the following other types implement trait `Valuable`:
             &T
             &[T]
@@ -25,8 +30,13 @@ error[E0277]: the trait bound `S: Valuable` is not satisfied
 10 | #[derive(Valuable)]
    |          -------- required by a bound introduced by this call
 11 | struct Tuple(Option<S>);
-   |              ^^^^^^^^^ the trait `Valuable` is not implemented for `S`
+   |              ^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `Valuable` is not implemented for `S`
+  --> tests/ui/not_valuable.rs:3:1
+   |
+ 3 | struct S;
+   | ^^^^^^^^
    = help: the following other types implement trait `Valuable`:
              &T
              &[T]
@@ -46,8 +56,13 @@ error[E0277]: the trait bound `S: Valuable` is not satisfied
    |          -------- required by a bound introduced by this call
 14 | enum Enum {
 15 |     Struct { f: Option<S> },
-   |                         ^ the trait `Valuable` is not implemented for `S`
+   |                         ^ unsatisfied trait bound
    |
+help: the trait `Valuable` is not implemented for `S`
+  --> tests/ui/not_valuable.rs:3:1
+   |
+ 3 | struct S;
+   | ^^^^^^^^
    = help: the following other types implement trait `Valuable`:
              &T
              &[T]
@@ -69,8 +84,13 @@ error[E0277]: the trait bound `S: Valuable` is not satisfied
    |          -------- required by a bound introduced by this call
 ...
 16 |     Tuple(Option<S>),
-   |                   ^ the trait `Valuable` is not implemented for `S`
+   |                   ^ unsatisfied trait bound
    |
+help: the trait `Valuable` is not implemented for `S`
+  --> tests/ui/not_valuable.rs:3:1
+   |
+ 3 | struct S;
+   | ^^^^^^^^
    = help: the following other types implement trait `Valuable`:
              &T
              &[T]

--- a/valuable-derive/src/attr.rs
+++ b/valuable-derive/src/attr.rs
@@ -42,12 +42,20 @@ static ATTRS: &[AttrDef] = &[
         ],
         style: &[MetaStyle::Ident],
     },
+    // #[valuable(crate = "...")]
+    AttrDef {
+        name: "crate",
+        conflicts_with: &[],
+        position: &[Position::Struct, Position::Enum],
+        style: &[MetaStyle::NameValue],
+    },
 ];
 
 pub(crate) struct Attrs {
     rename: Option<(syn::MetaNameValue, syn::LitStr)>,
     transparent: Option<Span>,
     skip: Option<Span>,
+    crate_path: Option<(syn::MetaNameValue, syn::Path)>,
 }
 
 impl Attrs {
@@ -65,12 +73,17 @@ impl Attrs {
     pub(crate) fn skip(&self) -> bool {
         self.skip.is_some()
     }
+
+    pub(crate) fn crate_path(&self) -> Option<&syn::Path> {
+        self.crate_path.as_ref().map(|(_, p)| p)
+    }
 }
 
 pub(crate) fn parse_attrs(cx: &Context, attrs: &[syn::Attribute], pos: Position) -> Attrs {
     let mut rename = None;
     let mut transparent = None;
     let mut skip = None;
+    let mut crate_path = None;
 
     let attrs = filter_attrs(cx, attrs, pos);
     for (def, meta) in &attrs {
@@ -94,6 +107,34 @@ pub(crate) fn parse_attrs(cx: &Context, attrs: &[syn::Attribute], pos: Position)
             }};
         }
 
+        macro_rules! lit_str_path {
+            ($field:ident) => {{
+                let m = match meta {
+                    Meta::NameValue(m) => m,
+                    _ => unreachable!(),
+                };
+                let lit = match &m.value {
+                    syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Str(l),
+                        ..
+                    }) => l,
+                    l => {
+                        cx.error(format_err!(l, "expected string literal"));
+                        continue;
+                    }
+                };
+                match lit.parse::<syn::Path>() {
+                    Ok(path) => {
+                        $field = Some((m.clone(), path));
+                    }
+                    Err(e) => {
+                        cx.error(format_err!(lit, "expected valid path: {}", e));
+                        continue;
+                    }
+                }
+            }};
+        }
+
         if def.late_check(cx, &attrs) {
             continue;
         }
@@ -104,6 +145,8 @@ pub(crate) fn parse_attrs(cx: &Context, attrs: &[syn::Attribute], pos: Position)
             "transparent" => transparent = Some(meta.span()),
             // #[valuable(skip)]
             "skip" => skip = Some(meta.span()),
+            // #[valuable(crate = "...")]
+            "crate" => lit_str_path!(crate_path),
 
             _ => unreachable!("{}", def.name),
         }
@@ -113,6 +156,7 @@ pub(crate) fn parse_attrs(cx: &Context, attrs: &[syn::Attribute], pos: Position)
         rename,
         transparent,
         skip,
+        crate_path,
     }
 }
 

--- a/valuable-derive/src/expand.rs
+++ b/valuable-derive/src/expand.rs
@@ -1,8 +1,15 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, ToTokens};
-use syn::{Error, Ident, Result};
+use syn::{Error, Ident, Path, Result};
 
 use crate::attr::{parse_attrs, Attrs, Context, Position};
+
+fn crate_path(attrs: &Attrs) -> Path {
+    attrs
+        .crate_path()
+        .cloned()
+        .unwrap_or_else(|| syn::parse_quote!(::valuable))
+}
 
 pub(crate) fn derive_valuable(input: &mut syn::DeriveInput) -> TokenStream {
     let cx = Context::default();
@@ -44,6 +51,7 @@ fn derive_struct(
 
     let name = &input.ident;
     let name_literal = struct_attrs.rename(name);
+    let valuable = crate_path(&struct_attrs);
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let allowed_lints = allowed_lints();
@@ -57,13 +65,13 @@ fn derive_struct(
         let access = respan(quote! { &self.#access }, &field.ty);
         let valuable_impl = quote! {
             #[automatically_derived]
-            impl #impl_generics ::valuable::Valuable for #name #ty_generics #where_clause {
-                fn as_value(&self) -> ::valuable::Value<'_> {
-                    ::valuable::Valuable::as_value(#access)
+            impl #impl_generics #valuable::Valuable for #name #ty_generics #where_clause {
+                fn as_value(&self) -> #valuable::Value<'_> {
+                    #valuable::Valuable::as_value(#access)
                 }
 
-                fn visit(&self, visitor: &mut dyn ::valuable::Visit) {
-                    ::valuable::Valuable::visit(#access, visitor);
+                fn visit(&self, visitor: &mut dyn #valuable::Visit) {
+                    #valuable::Valuable::visit(#access, visitor);
                 }
             }
         };
@@ -88,12 +96,13 @@ fn derive_struct(
                 &named_fields_static_name,
                 &data.fields,
                 &field_attrs,
+                &valuable,
             ));
 
             struct_def = quote! {
-                ::valuable::StructDef::new_static(
+                #valuable::StructDef::new_static(
                     #name_literal,
-                    ::valuable::Fields::Named(#named_fields_static_name),
+                    #valuable::Fields::Named(#named_fields_static_name),
                 )
             };
 
@@ -110,10 +119,10 @@ fn derive_struct(
                     respan(tokens, &field.ty)
                 });
             visit_fields = quote! {
-                visitor.visit_named_fields(&::valuable::NamedValues::new(
+                visitor.visit_named_fields(&#valuable::NamedValues::new(
                     #named_fields_static_name,
                     &[
-                        #(::valuable::Valuable::as_value(#fields),)*
+                        #(#valuable::Valuable::as_value(#fields),)*
                     ],
                 ));
             }
@@ -135,16 +144,16 @@ fn derive_struct(
 
             let len = indices.len();
             struct_def = quote! {
-                ::valuable::StructDef::new_static(
+                #valuable::StructDef::new_static(
                     #name_literal,
-                    ::valuable::Fields::Unnamed(#len),
+                    #valuable::Fields::Unnamed(#len),
                 )
             };
 
             visit_fields = quote! {
                 visitor.visit_unnamed_fields(
                     &[
-                        #(::valuable::Valuable::as_value(#indices),)*
+                        #(#valuable::Valuable::as_value(#indices),)*
                     ],
                 );
             };
@@ -153,8 +162,8 @@ fn derive_struct(
 
     let structable_impl = quote! {
         #[automatically_derived]
-        impl #impl_generics ::valuable::Structable for #name #ty_generics #where_clause {
-            fn definition(&self) -> ::valuable::StructDef<'_> {
+        impl #impl_generics #valuable::Structable for #name #ty_generics #where_clause {
+            fn definition(&self) -> #valuable::StructDef<'_> {
                 #struct_def
             }
         }
@@ -162,12 +171,12 @@ fn derive_struct(
 
     let valuable_impl = quote! {
         #[automatically_derived]
-        impl #impl_generics ::valuable::Valuable for #name #ty_generics #where_clause {
-            fn as_value(&self) -> ::valuable::Value<'_> {
-                ::valuable::Value::Structable(self)
+        impl #impl_generics #valuable::Valuable for #name #ty_generics #where_clause {
+            fn as_value(&self) -> #valuable::Value<'_> {
+                #valuable::Value::Structable(self)
             }
 
-            fn visit(&self, visitor: &mut dyn ::valuable::Visit) {
+            fn visit(&self, visitor: &mut dyn #valuable::Visit) {
                 #visit_fields
             }
         }
@@ -204,6 +213,7 @@ fn derive_enum(cx: Context, input: &syn::DeriveInput, data: &syn::DataEnum) -> R
 
     let name = &input.ident;
     let name_literal = enum_attrs.rename(name);
+    let valuable = crate_path(&enum_attrs);
 
     // <enum>_VARIANTS
     let variants_static_name = format_ident!("{}_VARIANTS", input.ident);
@@ -226,18 +236,19 @@ fn derive_enum(cx: Context, input: &syn::DeriveInput, data: &syn::DataEnum) -> R
                     &named_fields_static_name,
                     &variant.fields,
                     &field_attrs[variant_index],
+                    &valuable,
                 ));
 
                 variant_defs.push(quote! {
-                    ::valuable::VariantDef::new(
+                    #valuable::VariantDef::new(
                         #variant_name_literal,
-                        ::valuable::Fields::Named(#named_fields_static_name),
+                        #valuable::Fields::Named(#named_fields_static_name),
                     ),
                 });
 
                 variant_fn.push(quote! {
                     Self::#variant_name { .. } => {
-                        ::valuable::Variant::Static(&#variants_static_name[#variant_index])
+                        #valuable::Variant::Static(&#variants_static_name[#variant_index])
                     }
                 });
 
@@ -266,10 +277,10 @@ fn derive_enum(cx: Context, input: &syn::DeriveInput, data: &syn::DataEnum) -> R
                 visit_variants.push(quote! {
                     Self::#variant_name { #(#fields,)* #skipped } => {
                         visitor.visit_named_fields(
-                            &::valuable::NamedValues::new(
+                            &#valuable::NamedValues::new(
                                 #named_fields_static_name,
                                 &[
-                                    #(::valuable::Valuable::as_value(#as_value),)*
+                                    #(#valuable::Valuable::as_value(#as_value),)*
                                 ],
                             ),
                         );
@@ -279,7 +290,7 @@ fn derive_enum(cx: Context, input: &syn::DeriveInput, data: &syn::DataEnum) -> R
             syn::Fields::Unnamed(_) => {
                 variant_fn.push(quote! {
                     Self::#variant_name(..) => {
-                        ::valuable::Variant::Static(&#variants_static_name[#variant_index])
+                        #valuable::Variant::Static(&#variants_static_name[#variant_index])
                     }
                 });
 
@@ -303,9 +314,9 @@ fn derive_enum(cx: Context, input: &syn::DeriveInput, data: &syn::DataEnum) -> R
 
                 let len = as_value.len();
                 variant_defs.push(quote! {
-                    ::valuable::VariantDef::new(
+                    #valuable::VariantDef::new(
                         #variant_name_literal,
-                        ::valuable::Fields::Unnamed(#len),
+                        #valuable::Fields::Unnamed(#len),
                     ),
                 });
 
@@ -313,7 +324,7 @@ fn derive_enum(cx: Context, input: &syn::DeriveInput, data: &syn::DataEnum) -> R
                     Self::#variant_name(#(#bindings),*) => {
                         visitor.visit_unnamed_fields(
                             &[
-                                #(::valuable::Valuable::as_value(#as_value),)*
+                                #(#valuable::Valuable::as_value(#as_value),)*
                             ],
                         );
                     }
@@ -321,15 +332,15 @@ fn derive_enum(cx: Context, input: &syn::DeriveInput, data: &syn::DataEnum) -> R
             }
             syn::Fields::Unit => {
                 variant_defs.push(quote! {
-                    ::valuable::VariantDef::new(
+                    #valuable::VariantDef::new(
                         #variant_name_literal,
-                        ::valuable::Fields::Unnamed(0),
+                        #valuable::Fields::Unnamed(0),
                     ),
                 });
 
                 variant_fn.push(quote! {
                     Self::#variant_name => {
-                        ::valuable::Variant::Static(&#variants_static_name[#variant_index])
+                        #valuable::Variant::Static(&#variants_static_name[#variant_index])
                     }
                 });
 
@@ -345,7 +356,7 @@ fn derive_enum(cx: Context, input: &syn::DeriveInput, data: &syn::DataEnum) -> R
     }
 
     let variants_static = quote! {
-        static #variants_static_name: &[::valuable::VariantDef<'static>] = &[
+        static #variants_static_name: &[#valuable::VariantDef<'static>] = &[
             #(#variant_defs)*
         ];
     };
@@ -353,15 +364,15 @@ fn derive_enum(cx: Context, input: &syn::DeriveInput, data: &syn::DataEnum) -> R
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let enumerable_impl = quote! {
         #[automatically_derived]
-        impl #impl_generics ::valuable::Enumerable for #name #ty_generics #where_clause {
-            fn definition(&self) -> ::valuable::EnumDef<'_> {
-                ::valuable::EnumDef::new_static(
+        impl #impl_generics #valuable::Enumerable for #name #ty_generics #where_clause {
+            fn definition(&self) -> #valuable::EnumDef<'_> {
+                #valuable::EnumDef::new_static(
                     #name_literal,
                     #variants_static_name,
                 )
             }
 
-            fn variant(&self) -> ::valuable::Variant<'_> {
+            fn variant(&self) -> #valuable::Variant<'_> {
                 match self {
                     #(#variant_fn)*
                 }
@@ -371,12 +382,12 @@ fn derive_enum(cx: Context, input: &syn::DeriveInput, data: &syn::DataEnum) -> R
 
     let valuable_impl = quote! {
         #[automatically_derived]
-        impl #impl_generics ::valuable::Valuable for #name #ty_generics #where_clause {
-            fn as_value(&self) -> ::valuable::Value<'_> {
-                ::valuable::Value::Enumerable(self)
+        impl #impl_generics #valuable::Valuable for #name #ty_generics #where_clause {
+            fn as_value(&self) -> #valuable::Value<'_> {
+                #valuable::Value::Enumerable(self)
             }
 
-            fn visit(&self, visitor: &mut dyn ::valuable::Visit) {
+            fn visit(&self, visitor: &mut dyn #valuable::Visit) {
                 match self {
                     #(#visit_variants)*
                 }
@@ -397,7 +408,12 @@ fn derive_enum(cx: Context, input: &syn::DeriveInput, data: &syn::DataEnum) -> R
 }
 
 // `static <name>: &[NamedField<'static>] = &[ ... ];`
-fn named_fields_static(name: &Ident, fields: &syn::Fields, field_attrs: &[Attrs]) -> TokenStream {
+fn named_fields_static(
+    name: &Ident,
+    fields: &syn::Fields,
+    field_attrs: &[Attrs],
+    valuable: &Path,
+) -> TokenStream {
     debug_assert!(matches!(fields, syn::Fields::Named(..)));
     let named_fields = fields
         .iter()
@@ -406,11 +422,11 @@ fn named_fields_static(name: &Ident, fields: &syn::Fields, field_attrs: &[Attrs]
         .map(|(i, field)| {
             let field_name_literal = field_attrs[i].rename(field.ident.as_ref().unwrap());
             quote! {
-                ::valuable::NamedField::new(#field_name_literal),
+                #valuable::NamedField::new(#field_name_literal),
             }
         });
     quote! {
-        static #name: &[::valuable::NamedField<'static>] = &[
+        static #name: &[#valuable::NamedField<'static>] = &[
             #(#named_fields)*
         ];
     }

--- a/valuable-derive/src/lib.rs
+++ b/valuable-derive/src/lib.rs
@@ -27,6 +27,11 @@ use syn::parse_macro_input;
 ///
 /// Skip the field.
 ///
+/// ## `#[valuable(crate = "...")]`
+///
+/// Specify a custom path to the `valuable` crate. This is useful when
+/// re-exporting the derive macro from another crate.
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
Add support for `#[valuable(crate = "...")]` attribute to allow specifying a custom path to the valuable crate. This is useful when re-exporting the derive macro from another crate.

Example:
    mod my_crate {
        pub use valuable::*;
    }

    #[derive(my_crate::Valuable)]
    #[valuable(crate = "my_crate")]
    struct MyStruct { x: String }